### PR TITLE
feat: add per-repository configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,51 @@ pub struct Config {
 #[serde(deny_unknown_fields)]
 pub struct ReposConfig {
     #[serde(default)]
-    pub allowlist: Vec<String>,
+    pub allowlist: Vec<RepoEntry>,
+}
+
+/// Per-repository configuration entry in the YAML allowlist.
+///
+/// ```yaml
+/// repos:
+///   allowlist:
+///     - repo: "owner/name"
+///       skip_self_authored: false
+///       command: "claude code review"
+///       max_concurrency: 3
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepoEntry {
+    /// Repository in `"owner/name"` format.
+    pub repo: String,
+
+    /// Skip PRs authored by the authenticated user. Default: true.
+    #[serde(default = "default_true")]
+    pub skip_self_authored: bool,
+
+    /// Override the global `runner.command` for this repo.
+    #[serde(default)]
+    pub command: Option<String>,
+
+    /// Override the global `execution.max_concurrency` for this repo.
+    /// Reserved for future use; not yet wired into the runner.
+    #[serde(default)]
+    pub max_concurrency: Option<usize>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Parsed per-repository policy with a resolved `RepoId`.
+#[derive(Debug, Clone)]
+pub struct RepoPolicy {
+    pub id: crate::types::RepoId,
+    pub skip_self_authored: bool,
+    pub command: Option<String>,
+    /// Reserved for future use; not yet wired into the runner.
+    pub max_concurrency: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -287,10 +331,18 @@ impl Config {
             ));
         }
 
-        for repo in &self.repos.allowlist {
-            if !repo.contains('/') {
+        let mut seen = std::collections::HashSet::new();
+        for entry in &self.repos.allowlist {
+            if !entry.repo.contains('/') {
                 return Err(ReviewqError::Config(format!(
-                    "invalid repo format '{repo}': expected 'owner/name'"
+                    "invalid repo format '{}': expected 'owner/name'",
+                    entry.repo
+                )));
+            }
+            if !seen.insert(&entry.repo) {
+                return Err(ReviewqError::Config(format!(
+                    "duplicate repo '{}' in allowlist",
+                    entry.repo
                 )));
             }
         }
@@ -312,16 +364,26 @@ impl Config {
         }
     }
 
-    /// Parse a repo string from the allowlist into a `RepoId`.
-    pub fn parse_allowlist(&self) -> Vec<crate::types::RepoId> {
+    /// Parse the allowlist into per-repository policies.
+    pub fn repo_policies(&self) -> Vec<RepoPolicy> {
         self.repos
             .allowlist
             .iter()
-            .filter_map(|s| {
-                let (owner, name) = s.split_once('/')?;
-                Some(crate::types::RepoId::new(owner, name))
+            .filter_map(|entry| {
+                let (owner, name) = entry.repo.split_once('/')?;
+                Some(RepoPolicy {
+                    id: crate::types::RepoId::new(owner, name),
+                    skip_self_authored: entry.skip_self_authored,
+                    command: entry.command.clone(),
+                    max_concurrency: entry.max_concurrency,
+                })
             })
             .collect()
+    }
+
+    /// Extract just the repo IDs from the allowlist.
+    pub fn repo_ids(&self) -> Vec<crate::types::RepoId> {
+        self.repo_policies().into_iter().map(|p| p.id).collect()
     }
 }
 
@@ -345,12 +407,77 @@ mod tests {
         let yaml = r#"
 repos:
   allowlist:
-    - owner/repo
+    - repo: owner/repo
 "#;
         let config = Config::from_yaml(yaml).expect("should parse");
-        assert_eq!(config.repos.allowlist, vec!["owner/repo"]);
+        assert_eq!(config.repos.allowlist.len(), 1);
+        assert_eq!(config.repos.allowlist[0].repo, "owner/repo");
+        assert!(config.repos.allowlist[0].skip_self_authored);
+        assert!(config.repos.allowlist[0].command.is_none());
+        assert!(config.repos.allowlist[0].max_concurrency.is_none());
         assert_eq!(config.polling.interval_seconds, 300);
         assert_eq!(config.execution.max_concurrency, 10);
+    }
+
+    #[test]
+    fn parse_per_repo_overrides() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo1
+      skip_self_authored: false
+      command: "claude review"
+      max_concurrency: 3
+    - repo: org/repo2
+"#;
+        let config = Config::from_yaml(yaml).expect("should parse");
+        assert_eq!(config.repos.allowlist.len(), 2);
+
+        let e0 = &config.repos.allowlist[0];
+        assert_eq!(e0.repo, "org/repo1");
+        assert!(!e0.skip_self_authored);
+        assert_eq!(e0.command.as_deref(), Some("claude review"));
+        assert_eq!(e0.max_concurrency, Some(3));
+
+        let e1 = &config.repos.allowlist[1];
+        assert_eq!(e1.repo, "org/repo2");
+        assert!(e1.skip_self_authored);
+        assert!(e1.command.is_none());
+        assert!(e1.max_concurrency.is_none());
+    }
+
+    #[test]
+    fn repo_policies_returns_parsed_entries() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+      skip_self_authored: false
+      command: "echo review"
+      max_concurrency: 2
+"#;
+        let config = Config::from_yaml(yaml).expect("should parse");
+        let policies = config.repo_policies();
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0].id, crate::types::RepoId::new("org", "repo"));
+        assert!(!policies[0].skip_self_authored);
+        assert_eq!(policies[0].command.as_deref(), Some("echo review"));
+        assert_eq!(policies[0].max_concurrency, Some(2));
+    }
+
+    #[test]
+    fn repo_ids_extracts_ids() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo1
+    - repo: org/repo2
+"#;
+        let config = Config::from_yaml(yaml).expect("should parse");
+        let ids = config.repo_ids();
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids[0], crate::types::RepoId::new("org", "repo1"));
+        assert_eq!(ids[1], crate::types::RepoId::new("org", "repo2"));
     }
 
     #[test]
@@ -368,10 +495,22 @@ repos:
         let yaml = r#"
 repos:
   allowlist:
-    - just-a-name
+    - repo: just-a-name
 "#;
         let err = Config::from_yaml(yaml).unwrap_err();
         assert!(err.to_string().contains("owner/name"));
+    }
+
+    #[test]
+    fn reject_duplicate_repo() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+    - repo: org/repo
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("duplicate repo"));
     }
 
     #[test]
@@ -379,8 +518,8 @@ repos:
         let yaml = r#"
 repos:
   allowlist:
-    - org/repo1
-    - org/repo2
+    - repo: org/repo1
+    - repo: org/repo2
 polling:
   interval_seconds: 60
 auth:

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -6,7 +6,7 @@
 use tokio::time::{Duration, sleep};
 use tracing::{error, info, warn};
 
-use crate::config::Config;
+use crate::config::{Config, RepoPolicy};
 use crate::error::Result;
 use crate::traits::{GitHubClient, JobStore};
 use crate::types::{AgentKind, NewJob, RepoId};
@@ -18,10 +18,11 @@ where
     S: JobStore,
 {
     let username = github.authenticated_user().await?;
-    let repos = config.parse_allowlist();
+    let policies = config.repo_policies();
+    let repo_ids: Vec<RepoId> = policies.iter().map(|p| p.id.clone()).collect();
 
     loop {
-        match detect_once(github, store, config, &username, &repos).await {
+        match detect_once(github, store, config, &username, &repo_ids, &policies).await {
             Ok(count) => info!(new_jobs = count, "detection cycle complete"),
             Err(e) => {
                 if e.is_retryable() {
@@ -41,21 +42,26 @@ async fn detect_once<G, S>(
     store: &S,
     config: &Config,
     username: &str,
-    repos: &[RepoId],
+    repo_ids: &[RepoId],
+    policies: &[RepoPolicy],
 ) -> Result<usize>
 where
     G: GitHubClient,
     S: JobStore,
 {
-    let prs = github.search_review_requested(repos).await?;
+    let prs = github.search_review_requested(repo_ids).await?;
     info!(pr_count = prs.len(), "fetched PRs from GitHub");
 
     let agent_kind = AgentKind::default();
     let mut enqueued = 0;
 
     for pr in &prs {
+        // Look up per-repo policy (default: skip_self_authored = true).
+        let policy = policies.iter().find(|p| p.id == pr.repo);
+        let skip_self = policy.is_none_or(|p| p.skip_self_authored);
+
         // Apply filtering rules
-        if !crate::rules::should_process(pr, username, repos) {
+        if !crate::rules::should_process(pr, username, repo_ids, skip_self) {
             continue;
         }
 
@@ -76,13 +82,18 @@ where
             continue;
         }
 
+        // Resolve command: per-repo override > global runner.command.
+        let command = policy
+            .and_then(|p| p.command.clone())
+            .or_else(|| config.runner.command.clone());
+
         // Enqueue new job
         let new_job = NewJob {
             repo: pr.repo.clone(),
             pr_number: pr.number,
             head_sha: pr.head_sha.clone(),
             agent_kind: agent_kind.clone(),
-            command: config.runner.command.clone(),
+            command,
             max_retries: 3,
         };
 
@@ -147,7 +158,21 @@ mod tests {
             r#"
 repos:
   allowlist:
-    - org/repo
+    - repo: org/repo
+polling:
+  interval_seconds: 60
+"#,
+        )
+        .expect("config should parse")
+    }
+
+    fn test_config_skip_self_disabled() -> Config {
+        Config::from_yaml(
+            r#"
+repos:
+  allowlist:
+    - repo: org/repo
+      skip_self_authored: false
 polling:
   interval_seconds: 60
 "#,
@@ -176,9 +201,10 @@ polling:
         };
         let db = Database::open_in_memory().expect("db");
         let config = test_config();
-        let repos = config.parse_allowlist();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repos)
+        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -197,16 +223,17 @@ polling:
         };
         let db = Database::open_in_memory().expect("db");
         let config = test_config();
-        let repos = config.parse_allowlist();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
 
         // First cycle should enqueue
-        let count1 = detect_once(&github, &db, &config, "bob", &repos)
+        let count1 = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
 
         // Second cycle should skip (idempotent)
-        let count2 = detect_once(&github, &db, &config, "bob", &repos)
+        let count2 = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 0);
@@ -220,12 +247,95 @@ polling:
         };
         let db = Database::open_in_memory().expect("db");
         let config = test_config();
-        let repos = config.parse_allowlist();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "alice", &repos)
+        let count = detect_once(&github, &db, &config, "alice", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn accepts_self_authored_when_skip_disabled() {
+        let mut pr = make_pr(1, "sha1");
+        pr.requested_reviewers.push("alice".into());
+        let github = MockGitHub {
+            username: "alice".into(),
+            prs: vec![pr],
+        };
+        let db = Database::open_in_memory().expect("db");
+        let config = test_config_skip_self_disabled();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
+
+        let count = detect_once(&github, &db, &config, "alice", &repo_ids, &policies)
+            .await
+            .expect("should succeed");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn per_repo_command_overrides_global() {
+        let github = MockGitHub {
+            username: "bob".into(),
+            prs: vec![make_pr(1, "sha1")],
+        };
+        let db = Database::open_in_memory().expect("db");
+        let config = Config::from_yaml(
+            r#"
+repos:
+  allowlist:
+    - repo: org/repo
+      command: "per-repo-cmd"
+runner:
+  command: "global-cmd"
+polling:
+  interval_seconds: 60
+"#,
+        )
+        .expect("config");
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
+
+        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+            .await
+            .expect("should succeed");
+        assert_eq!(count, 1);
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs[0].command.as_deref(), Some("per-repo-cmd"));
+    }
+
+    #[tokio::test]
+    async fn global_command_used_when_no_per_repo_override() {
+        let github = MockGitHub {
+            username: "bob".into(),
+            prs: vec![make_pr(1, "sha1")],
+        };
+        let db = Database::open_in_memory().expect("db");
+        let config = Config::from_yaml(
+            r#"
+repos:
+  allowlist:
+    - repo: org/repo
+runner:
+  command: "global-cmd"
+polling:
+  interval_seconds: 60
+"#,
+        )
+        .expect("config");
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
+
+        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+            .await
+            .expect("should succeed");
+        assert_eq!(count, 1);
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs[0].command.as_deref(), Some("global-cmd"));
     }
 
     #[tokio::test]
@@ -238,9 +348,10 @@ polling:
         };
         let db = Database::open_in_memory().expect("db");
         let config = test_config();
-        let repos = config.parse_allowlist();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repos)
+        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0);
@@ -250,14 +361,15 @@ polling:
     async fn requeues_on_sha_change() {
         let db = Database::open_in_memory().expect("db");
         let config = test_config();
-        let repos = config.parse_allowlist();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
 
         // First cycle with old SHA
         let github1 = MockGitHub {
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repos)
+        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -267,7 +379,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repos)
+        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 1);
@@ -285,9 +397,10 @@ polling:
         };
         let db = Database::open_in_memory().expect("db");
         let config = test_config();
-        let repos = config.parse_allowlist();
+        let policies = config.repo_policies();
+        let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repos)
+        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use tracing::{error, info, warn};
 #[command(name = "reviewq", version, about)]
 struct Cli {
     /// Path to the configuration file.
-    #[arg(short, long, default_value = "reviewq.yml")]
-    config: PathBuf,
+    #[arg(short, long)]
+    config: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -55,8 +55,21 @@ async fn main() {
     }
 }
 
+/// Resolve the configuration file path.
+///
+/// Priority: `--config` flag > `~/.reviewq/config.yml` default.
+fn resolve_config_path(explicit: Option<PathBuf>) -> PathBuf {
+    if let Some(p) = explicit {
+        return p;
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".reviewq").join("config.yml"))
+        .unwrap_or_else(|| PathBuf::from("reviewq.yml"))
+}
+
 async fn run(cli: Cli) -> reviewq::error::Result<()> {
-    let mut config = reviewq::config::Config::load(&cli.config)?;
+    let config_path = resolve_config_path(cli.config);
+    let mut config = reviewq::config::Config::load(&config_path)?;
     config.expand_paths();
 
     match cli.command {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -5,11 +5,18 @@
 use crate::types::{PrState, PullRequest, RepoId};
 
 /// Check if a PR passes all filtering rules.
-pub fn should_process(pr: &PullRequest, username: &str, allowlist: &[RepoId]) -> bool {
+///
+/// `skip_self_authored` is resolved per-repo from the configuration.
+pub fn should_process(
+    pr: &PullRequest,
+    username: &str,
+    allowlist: &[RepoId],
+    skip_self_authored: bool,
+) -> bool {
     is_in_allowlist(pr, allowlist)
         && is_open(pr)
         && !is_draft(pr)
-        && !is_self_authored(pr, username)
+        && (!skip_self_authored || !is_self_authored(pr, username))
         && is_review_requested(pr, username)
 }
 
@@ -57,54 +64,61 @@ mod tests {
     #[test]
     fn passes_all_rules() {
         let pr = make_pr();
-        assert!(should_process(&pr, "bob", &allowlist()));
+        assert!(should_process(&pr, "bob", &allowlist(), true));
     }
 
     #[test]
     fn rejects_repo_not_in_allowlist() {
         let mut pr = make_pr();
         pr.repo = RepoId::new("other", "repo");
-        assert!(!should_process(&pr, "bob", &allowlist()));
+        assert!(!should_process(&pr, "bob", &allowlist(), true));
     }
 
     #[test]
     fn rejects_closed_pr() {
         let mut pr = make_pr();
         pr.state = PrState::Closed;
-        assert!(!should_process(&pr, "bob", &allowlist()));
+        assert!(!should_process(&pr, "bob", &allowlist(), true));
     }
 
     #[test]
     fn rejects_merged_pr() {
         let mut pr = make_pr();
         pr.state = PrState::Merged;
-        assert!(!should_process(&pr, "bob", &allowlist()));
+        assert!(!should_process(&pr, "bob", &allowlist(), true));
     }
 
     #[test]
     fn rejects_draft_pr() {
         let mut pr = make_pr();
         pr.draft = true;
-        assert!(!should_process(&pr, "bob", &allowlist()));
+        assert!(!should_process(&pr, "bob", &allowlist(), true));
     }
 
     #[test]
     fn rejects_self_authored_pr() {
         let pr = make_pr();
-        assert!(!should_process(&pr, "alice", &allowlist()));
+        assert!(!should_process(&pr, "alice", &allowlist(), true));
+    }
+
+    #[test]
+    fn accepts_self_authored_when_skip_disabled() {
+        let mut pr = make_pr();
+        pr.requested_reviewers.push("alice".into());
+        assert!(should_process(&pr, "alice", &allowlist(), false));
     }
 
     #[test]
     fn rejects_no_review_requested() {
         let mut pr = make_pr();
         pr.requested_reviewers.clear();
-        assert!(!should_process(&pr, "bob", &allowlist()));
+        assert!(!should_process(&pr, "bob", &allowlist(), true));
     }
 
     #[test]
     fn rejects_review_requested_for_different_user() {
         let pr = make_pr();
-        assert!(!should_process(&pr, "charlie", &allowlist()));
+        assert!(!should_process(&pr, "charlie", &allowlist(), true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Convert `repos.allowlist` from plain string list to structured `RepoEntry` objects, enabling per-repository configuration for `skip_self_authored`, `command`, and `max_concurrency`
- Move default config path from `./reviewq.yml` to `~/.reviewq/config.yml` (user-space)
- Add duplicate repo validation and comprehensive tests for the new config format

### YAML format (before → after)

```yaml
# Before
repos:
  allowlist:
    - "owner/repo"

# After
repos:
  allowlist:
    - repo: "owner/repo"
      skip_self_authored: false
      command: "claude code review"
      max_concurrency: 3
```

### Per-repo field behavior

| Field | Default | Fallback |
|-------|---------|----------|
| `skip_self_authored` | `true` | — |
| `command` | `None` | global `runner.command` |
| `max_concurrency` | `None` | reserved for future use |

## Test plan

- [x] 74 unit tests + 5 integration tests passing
- [x] `cargo clippy -- -D warnings` clean
- [x] New tests: `parse_per_repo_overrides`, `repo_policies_returns_parsed_entries`, `repo_ids_extracts_ids`, `reject_duplicate_repo`, `accepts_self_authored_when_skip_disabled`, `per_repo_command_overrides_global`, `global_command_used_when_no_per_repo_override`
- [x] Codex code review LGTM (Round 2)