### PR TITLE
feat: convert review markdown to HTML and open in browser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod executor;
 pub mod github;
 pub mod idempotency;
 pub mod logging;
+pub mod review_html;
 pub mod rules;
 pub mod runner;
 pub mod traits;

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ async fn run(cli: Cli) -> reviewq::error::Result<()> {
         }
         Some(Commands::Tui) => {
             let db = reviewq::db::Database::open(&config.state.sqlite_path)?;
-            reviewq::tui::run(&db)
+            reviewq::tui::run(&db, &config.output.dir)
         }
         None => run_daemon(config).await,
     }

--- a/src/review_html.rs
+++ b/src/review_html.rs
@@ -1,0 +1,353 @@
+//! Markdown → HTML conversion and file output for review results.
+//!
+//! Converts review markdown to a styled HTML document using comrak (GFM),
+//! writes both `.md` and `.html` files to the output directory.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use comrak::{Options, markdown_to_html};
+
+use crate::error::{Result, ReviewqError};
+
+/// Paths to the generated review artifact files.
+#[derive(Debug, Clone)]
+pub struct ReviewArtifact {
+    pub md_path: PathBuf,
+    pub html_path: PathBuf,
+}
+
+/// Convert GFM markdown to an HTML body fragment using comrak.
+fn markdown_to_html_body(markdown: &str) -> String {
+    let mut options = Options::default();
+    options.extension.strikethrough = true;
+    options.extension.table = true;
+    options.extension.autolink = true;
+    options.extension.tasklist = true;
+    options.extension.header_ids = Some(String::new());
+    // Do not allow raw HTML passthrough.
+    options.render.unsafe_ = false;
+
+    markdown_to_html(markdown, &options)
+}
+
+/// Render a full HTML document from markdown review content.
+pub fn render_html(markdown: &str, title: &str) -> String {
+    let body = markdown_to_html_body(markdown);
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{title}</title>
+<style>
+{css}
+</style>
+</head>
+<body>
+<div class="container">
+<h1 class="page-title">{title}</h1>
+{body}
+</div>
+</body>
+</html>"#,
+        title = html_escape(title),
+        css = CSS_TEMPLATE,
+        body = body,
+    )
+}
+
+/// Generate the output filename stem.
+///
+/// Format: `{owner}_{repo_name}_pr{pr_number}_{YYYYMMDD_HHMMSS}_{head_sha_short}`
+fn output_stem(
+    owner: &str,
+    repo_name: &str,
+    pr_number: u64,
+    created_at: DateTime<Utc>,
+    head_sha: &str,
+) -> String {
+    let sha_short = &head_sha[..7.min(head_sha.len())];
+    let timestamp = created_at.format("%Y%m%d_%H%M%S");
+    let owner_safe = sanitize_filename(owner);
+    let repo_safe = sanitize_filename(repo_name);
+    format!("{owner_safe}_{repo_safe}_pr{pr_number}_{timestamp}_{sha_short}")
+}
+
+/// Write review markdown and HTML files to the output directory.
+///
+/// Returns [`ReviewArtifact`] with paths to both generated files.
+pub fn write_review_files(
+    markdown: &str,
+    owner: &str,
+    repo_name: &str,
+    pr_number: u64,
+    head_sha: &str,
+    created_at: DateTime<Utc>,
+    output_dir: &Path,
+) -> Result<ReviewArtifact> {
+    std::fs::create_dir_all(output_dir).map_err(|e| {
+        ReviewqError::Process(format!(
+            "failed to create output directory {}: {e}",
+            output_dir.display()
+        ))
+    })?;
+
+    let stem = output_stem(owner, repo_name, pr_number, created_at, head_sha);
+    let title = format!("{owner}/{repo_name} PR #{pr_number}");
+
+    // Write .md file.
+    let md_path = output_dir.join(format!("{stem}.md"));
+    std::fs::write(&md_path, markdown).map_err(|e| {
+        ReviewqError::Process(format!(
+            "failed to write markdown {}: {e}",
+            md_path.display()
+        ))
+    })?;
+
+    // Write .html file.
+    let html = render_html(markdown, &title);
+    let html_path = output_dir.join(format!("{stem}.html"));
+    std::fs::write(&html_path, &html).map_err(|e| {
+        ReviewqError::Process(format!("failed to write HTML {}: {e}", html_path.display()))
+    })?;
+
+    Ok(ReviewArtifact { md_path, html_path })
+}
+
+/// Replace path-unsafe characters with underscores.
+fn sanitize_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            '/' | '\\' | ' ' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
+/// Minimal HTML escaping for attribute/title contexts.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Embedded CSS for review HTML output.
+const CSS_TEMPLATE: &str = r#"
+:root {
+    --bg: #ffffff;
+    --fg: #1a1a2e;
+    --code-bg: #f5f5f7;
+    --border: #e0e0e4;
+    --link: #2563eb;
+    --heading-border: #3b82f6;
+    --table-stripe: #f9fafb;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #1a1a2e;
+        --fg: #e0e0e4;
+        --code-bg: #252540;
+        --border: #3a3a5c;
+        --link: #60a5fa;
+        --heading-border: #3b82f6;
+        --table-stripe: #1e1e36;
+    }
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.7;
+    color: var(--fg);
+    background: var(--bg);
+    padding: 2rem 1rem;
+}
+
+.container {
+    max-width: 52rem;
+    margin: 0 auto;
+}
+
+.page-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 3px solid var(--heading-border);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    margin-top: 1.8rem;
+    margin-bottom: 0.6rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+h1 { font-size: 1.6rem; border-bottom: 2px solid var(--border); padding-bottom: 0.3rem; }
+h2 { font-size: 1.3rem; }
+h3 { font-size: 1.1rem; }
+
+p { margin-bottom: 0.8rem; }
+
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+    font-size: 0.875em;
+    background: var(--code-bg);
+    padding: 0.15em 0.35em;
+    border-radius: 4px;
+}
+
+pre {
+    background: var(--code-bg);
+    padding: 1rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+    border: 1px solid var(--border);
+}
+
+pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1.5;
+}
+
+blockquote {
+    border-left: 4px solid var(--heading-border);
+    padding: 0.5rem 1rem;
+    margin: 0.8rem 0;
+    background: var(--code-bg);
+    border-radius: 0 4px 4px 0;
+}
+
+ul, ol {
+    padding-left: 1.5rem;
+    margin-bottom: 0.8rem;
+}
+
+li { margin-bottom: 0.3rem; }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    font-size: 0.9em;
+}
+
+th, td {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    text-align: left;
+}
+
+th { background: var(--code-bg); font-weight: 600; }
+tr:nth-child(even) { background: var(--table-stripe); }
+
+ul.contains-task-list { list-style: none; padding-left: 0; }
+
+li.task-list-item { padding-left: 1.5rem; position: relative; }
+
+li.task-list-item input[type="checkbox"] {
+    position: absolute;
+    left: 0;
+    top: 0.35em;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 1.5rem 0;
+}
+
+img { max-width: 100%; height: auto; border-radius: 4px; }
+"#;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use tempfile::TempDir;
+
+    #[test]
+    fn render_html_basic() {
+        let html = render_html("# Hello\n\nWorld", "Test PR");
+        assert!(html.contains("<h1"));
+        assert!(html.contains("Hello"));
+        assert!(html.contains("<p>World</p>"));
+        assert!(html.contains("<title>Test PR</title>"));
+    }
+
+    #[test]
+    fn render_html_gfm_extensions() {
+        let md = "- [x] Done\n- [ ] TODO\n\n| A | B |\n|---|---|\n| 1 | 2 |";
+        let html = render_html(md, "GFM Test");
+        assert!(html.contains("<table>"));
+        assert!(html.contains("checkbox"));
+    }
+
+    #[test]
+    fn output_stem_format() {
+        let ts = Utc.with_ymd_and_hms(2026, 2, 22, 15, 30, 45).unwrap();
+        let stem = output_stem("myorg", "myrepo", 42, ts, "abc1234def");
+        assert_eq!(stem, "myorg_myrepo_pr42_20260222_153045_abc1234");
+    }
+
+    #[test]
+    fn write_review_files_creates_md_and_html() {
+        let tmp = TempDir::new().expect("temp dir");
+        let ts = Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap();
+
+        let artifact = write_review_files(
+            "# Review\n\nLGTM",
+            "org",
+            "testrepo",
+            7,
+            "deadbeef1234567",
+            ts,
+            tmp.path(),
+        )
+        .expect("write should succeed");
+
+        assert!(artifact.html_path.exists());
+        assert!(artifact.md_path.exists());
+        assert!(artifact.html_path.to_str().unwrap().ends_with(".html"));
+        assert!(artifact.md_path.to_str().unwrap().ends_with(".md"));
+
+        let html_content = std::fs::read_to_string(&artifact.html_path).expect("read html");
+        assert!(html_content.contains("Review"));
+        assert!(html_content.contains("LGTM"));
+
+        let md_content = std::fs::read_to_string(&artifact.md_path).expect("read md");
+        assert_eq!(md_content, "# Review\n\nLGTM");
+    }
+
+    #[test]
+    fn sanitize_filename_replaces_unsafe_chars() {
+        assert_eq!(sanitize_filename("owner/repo"), "owner_repo");
+        assert_eq!(sanitize_filename("a b"), "a_b");
+        assert_eq!(sanitize_filename("a\\b:c"), "a_b_c");
+        assert_eq!(sanitize_filename("normal"), "normal");
+    }
+
+    #[test]
+    fn html_escape_special_chars() {
+        assert_eq!(html_escape("<script>"), "&lt;script&gt;");
+        assert_eq!(html_escape("a & b"), "a &amp; b");
+        assert_eq!(html_escape(r#"say "hi""#), "say &quot;hi&quot;");
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,7 @@
 //! TUI application state and action dispatch.
 
+use std::path::PathBuf;
+
 use crate::types::{Job, JobStatus};
 
 /// Active view in the TUI.
@@ -36,20 +38,19 @@ pub struct App {
     pub status_message: Option<String>,
     /// Cached log content for the tail view.
     pub log_content: String,
-    /// Cached review text for the review view.
+    /// Cached review text for the review view (fallback).
     pub review_text: String,
     /// Cached command text for the prompt view.
     pub command_text: String,
-}
-
-impl Default for App {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// Output directory for review HTML/markdown files.
+    pub output_dir: PathBuf,
+    /// Path to open in the browser after dispatch completes.
+    /// The event loop in `tui/mod.rs` drains this to call `open::that`.
+    pub pending_open: Option<PathBuf>,
 }
 
 impl App {
-    pub fn new() -> Self {
+    pub fn new(output_dir: PathBuf) -> Self {
         Self {
             view: View::Queue,
             jobs: Vec::new(),
@@ -59,6 +60,8 @@ impl App {
             log_content: String::new(),
             review_text: String::new(),
             command_text: String::new(),
+            output_dir,
+            pending_open: None,
         }
     }
 
@@ -85,9 +88,41 @@ impl App {
             }
             Action::SelectJob => {
                 if let Some(job) = self.selected_job() {
-                    if let Some(ref output) = job.review_output {
-                        self.review_text = output.clone();
-                        self.view = View::Review;
+                    if let Some(ref markdown) = job.review_output {
+                        // Clone fields needed after releasing the borrow on self.
+                        let markdown = markdown.clone();
+                        let owner = job.repo.owner.clone();
+                        let repo_name = job.repo.name.clone();
+                        let pr_number = job.pr_number;
+                        let head_sha = job.head_sha.clone();
+                        let created_at = job.created_at;
+
+                        match crate::review_html::write_review_files(
+                            &markdown,
+                            &owner,
+                            &repo_name,
+                            pr_number,
+                            &head_sha,
+                            created_at,
+                            &self.output_dir,
+                        ) {
+                            Ok(artifact) => {
+                                // Defer browser open to the event loop (avoids
+                                // opening a browser during tests).
+                                self.status_message = Some(format!(
+                                    "Opened review: {}",
+                                    artifact.html_path.display()
+                                ));
+                                self.pending_open = Some(artifact.html_path);
+                            }
+                            Err(e) => {
+                                // File generation failed — fall back to TUI
+                                // with error note prepended so the user sees why.
+                                self.review_text =
+                                    format!("[HTML generation failed: {e}]\n\n{markdown}");
+                                self.view = View::Review;
+                            }
+                        }
                     } else {
                         self.status_message = Some("No review output available".to_owned());
                     }
@@ -204,6 +239,13 @@ mod tests {
     use super::*;
     use crate::types::{AgentKind, RepoId};
     use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn make_app() -> (App, TempDir) {
+        let tmp = TempDir::new().expect("temp dir");
+        let app = App::new(tmp.path().to_path_buf());
+        (app, tmp)
+    }
 
     fn make_job(id: i64, status: JobStatus) -> Job {
         Job {
@@ -231,7 +273,7 @@ mod tests {
 
     #[test]
     fn new_app_defaults() {
-        let app = App::new();
+        let (app, _tmp) = make_app();
         assert_eq!(app.view, View::Queue);
         assert!(app.jobs.is_empty());
         assert_eq!(app.selected_index, 0);
@@ -240,7 +282,7 @@ mod tests {
 
     #[test]
     fn navigation_clamps_to_bounds() {
-        let mut app = App::new();
+        let (mut app, _tmp) = make_app();
         app.update_jobs(vec![
             make_job(1, JobStatus::Queued),
             make_job(2, JobStatus::Running),
@@ -262,7 +304,7 @@ mod tests {
 
     #[test]
     fn update_jobs_clamps_index() {
-        let mut app = App::new();
+        let (mut app, _tmp) = make_app();
         app.update_jobs(vec![
             make_job(1, JobStatus::Queued),
             make_job(2, JobStatus::Queued),
@@ -277,16 +319,55 @@ mod tests {
 
     #[test]
     fn quit_action_sets_flag() {
-        let mut app = App::new();
+        let (mut app, _tmp) = make_app();
         app.dispatch(Action::Quit);
         assert!(app.should_quit);
     }
 
     #[test]
     fn go_back_returns_to_queue() {
-        let mut app = App::new();
+        let (mut app, _tmp) = make_app();
         app.view = View::Tail;
         app.dispatch(Action::GoBack);
+        assert_eq!(app.view, View::Queue);
+    }
+
+    #[test]
+    fn select_job_without_review_output_shows_message() {
+        let (mut app, _tmp) = make_app();
+        app.update_jobs(vec![make_job(1, JobStatus::Succeeded)]);
+
+        app.dispatch(Action::SelectJob);
+        assert_eq!(app.view, View::Queue);
+        assert!(
+            app.status_message
+                .as_deref()
+                .unwrap()
+                .contains("No review output")
+        );
+    }
+
+    #[test]
+    fn select_job_with_review_output_generates_html() {
+        let (mut app, _tmp) = make_app();
+        let mut job = make_job(1, JobStatus::Succeeded);
+        job.review_output = Some("# LGTM\n\nAll good.".into());
+        app.update_jobs(vec![job]);
+
+        app.dispatch(Action::SelectJob);
+
+        // dispatch sets pending_open instead of calling open::that directly,
+        // so no browser is launched during tests.
+        assert!(app.pending_open.is_some(), "should have pending_open set");
+        let html_path = app.pending_open.as_ref().unwrap();
+        assert!(html_path.exists(), "HTML file should have been written");
+        assert!(html_path.to_str().unwrap().ends_with(".html"));
+
+        // Also verify .md was written alongside.
+        let md_path = html_path.with_extension("md");
+        assert!(md_path.exists(), "markdown file should have been written");
+
+        // Should stay on Queue view (browser open is deferred to event loop).
         assert_eq!(app.view, View::Queue);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -8,6 +8,7 @@ pub mod tail_view;
 pub mod widgets;
 
 use std::io;
+use std::path::Path;
 
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use crossterm::execute;
@@ -21,7 +22,7 @@ use crate::traits::JobStore;
 use crate::types::JobFilter;
 
 /// Run the TUI application.
-pub fn run<S: JobStore>(store: &S) -> Result<()> {
+pub fn run<S: JobStore>(store: &S, output_dir: &Path) -> Result<()> {
     // Setup terminal
     terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -37,7 +38,7 @@ pub fn run<S: JobStore>(store: &S) -> Result<()> {
         original_hook(panic_info);
     }));
 
-    let mut app = App::new();
+    let mut app = App::new(output_dir.to_path_buf());
 
     // Initial load
     app.update_jobs(store.list_jobs(&JobFilter::default())?);
@@ -51,6 +52,19 @@ pub fn run<S: JobStore>(store: &S) -> Result<()> {
             && let Some(action) = map_key(key, &app)
         {
             app.dispatch(action);
+        }
+
+        // Open browser if dispatch requested it.
+        if let Some(path) = app.pending_open.take()
+            && open::that(&path).is_err()
+        {
+            // Browser open failed — fall back to TUI review view.
+            app.review_text = format!(
+                "[Failed to open browser: {}]\n\n{}",
+                path.display(),
+                app.review_text
+            );
+            app.view = View::Review;
         }
 
         if app.should_quit {

--- a/src/tui/queue_view.rs
+++ b/src/tui/queue_view.rs
@@ -11,7 +11,7 @@ use super::widgets;
 
 /// Key binding hints displayed at the bottom of the queue view.
 const KEY_HINTS: &str =
-    " j/↓ Down  k/↑ Up  Enter Review  t Tail  p Prompt  x Cancel  r Retry  o Open  q Quit ";
+    " j/↓ Down  k/↑ Up  Enter Open  t Tail  p Prompt  x Cancel  r Retry  o PR  q Quit ";
 
 /// Render the queue view.
 pub fn render(f: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary
- Add `review_html` module that converts review markdown to styled HTML using comrak (GFM extensions: tables, task lists, strikethrough, autolinks, header IDs)
- Press `Enter` on a job in TUI → generates `.md` + `.html` files in `~/.reviewq/output/` → opens HTML in default browser
- Falls back to raw markdown display in TUI if HTML generation or browser open fails, with error note prepended to the review text
- File naming: `{owner}_{repo}_pr{number}_{YYYYMMDD_HHMMSS}_{sha_short}.{md,html}`
- Embedded CSS with dark mode support (`prefers-color-scheme`), code block styling, table striping
- Returns `ReviewArtifact { md_path, html_path }` for clean API separation
- Updates TUI key hints (`Enter Open`, `o PR`)

## Files changed
| File | Description |
|------|-------------|
| `src/review_html.rs` | **New** — markdown→HTML conversion, HTML template, file output |
| `src/lib.rs` | Add `pub mod review_html` |
| `src/tui/app.rs` | Add `output_dir` to `App`, change `SelectJob` to HTML+browser with fallback |
| `src/tui/mod.rs` | Accept `output_dir` parameter |
| `src/main.rs` | Pass `config.output.dir` to TUI |
| `src/tui/queue_view.rs` | Update key hint text |

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 90 unit tests + 5 integration tests pass (95 total)
- [ ] Manual: `reviewq tui` → Enter on completed job → browser opens with styled HTML review
- [ ] Manual: verify fallback to TUI raw markdown when no browser available