### PR TITLE
feat: template variable interpolation and env var injection for runner commands

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -19,6 +19,88 @@ use crate::types::{Job, ReviewResult};
 /// Well-known filename that review agents write their output to.
 const REVIEW_OUTPUT_FILE: &str = "REVIEW.md";
 
+// ---------------------------------------------------------------------------
+// Template variable interpolation
+// ---------------------------------------------------------------------------
+
+/// Holds all values available for template variable interpolation and
+/// environment variable injection.
+struct TemplateContext {
+    pr_url: String,
+    repo: String,
+    pr_number: String,
+    head_sha: String,
+    worktree_path: String,
+    job_id: String,
+    output_path: String,
+}
+
+impl TemplateContext {
+    /// Build a context from a [`Job`] and its worktree path.
+    fn new(job: &Job, worktree: &Path) -> Self {
+        let repo = job.repo.full_name();
+        let pr_number = job.pr_number.to_string();
+        let pr_url = format!("https://github.com/{}/pull/{}", repo, pr_number);
+        Self {
+            pr_url,
+            repo,
+            pr_number,
+            head_sha: job.head_sha.clone(),
+            worktree_path: worktree.display().to_string(),
+            job_id: job.id.to_string(),
+            output_path: worktree.join(REVIEW_OUTPUT_FILE).display().to_string(),
+        }
+    }
+
+    /// Replace all known `{variable}` placeholders in a command template.
+    fn interpolate(&self, template: &str) -> String {
+        template
+            .replace("{pr_url}", &self.pr_url)
+            .replace("{repo}", &self.repo)
+            .replace("{pr_number}", &self.pr_number)
+            .replace("{head_sha}", &self.head_sha)
+            .replace("{worktree_path}", &self.worktree_path)
+            .replace("{job_id}", &self.job_id)
+            .replace("{output_path}", &self.output_path)
+    }
+
+    /// Return `REVIEWQ_*` environment variable pairs for the child process.
+    fn env_vars(&self) -> Vec<(String, String)> {
+        vec![
+            ("REVIEWQ_PR_URL".into(), self.pr_url.clone()),
+            ("REVIEWQ_REPO".into(), self.repo.clone()),
+            ("REVIEWQ_PR_NUMBER".into(), self.pr_number.clone()),
+            ("REVIEWQ_HEAD_SHA".into(), self.head_sha.clone()),
+            ("REVIEWQ_WORKTREE_PATH".into(), self.worktree_path.clone()),
+            ("REVIEWQ_JOB_ID".into(), self.job_id.clone()),
+            ("REVIEWQ_OUTPUT_PATH".into(), self.output_path.clone()),
+        ]
+    }
+}
+
+/// Log a warning for any remaining `{identifier}` patterns in a command after
+/// interpolation. Shell constructs like `${VAR}` are intentionally ignored.
+fn warn_unknown_variables(command: &str) {
+    let mut rest = command;
+    while let Some(start) = rest.find('{') {
+        let after_brace = &rest[start + 1..];
+        if let Some(end) = after_brace.find('}') {
+            let name = &after_brace[..end];
+            // Only warn for simple identifiers (non-empty, ASCII alphanumeric + underscore).
+            // Skip shell constructs like ${VAR} (contains $) or empty braces {}.
+            if !name.is_empty()
+                && !name.contains('$')
+                && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+            {
+                warn!(variable = name, "unknown template variable in command");
+            }
+            rest = &after_brace[end + 1..];
+        } else {
+            break;
+        }
+    }
+}
+
 /// Command-based review executor.
 ///
 /// Spawns a shell command in a new process group within the job's worktree.
@@ -73,15 +155,19 @@ impl ReviewExecutor for CommandExecutor {
         let stderr_path = self.output_dir.join(format!("job-{}-stderr.log", job.id));
 
         // Use job-specific command if set, otherwise the default.
-        let cmd = job.command.as_deref().unwrap_or(&self.command);
+        let raw_cmd = job.command.as_deref().unwrap_or(&self.command);
+        let ctx = TemplateContext::new(job, worktree);
+        let cmd = ctx.interpolate(raw_cmd);
+        warn_unknown_variables(&cmd);
+        let env_vars = ctx.env_vars();
 
         let (mut child, pid) =
-            process::spawn_in_group(cmd, worktree, &stdout_path, &stderr_path).await?;
+            process::spawn_in_group(&cmd, worktree, &stdout_path, &stderr_path, &env_vars).await?;
 
         info!(
             job_id = job.id,
             pid,
-            command = cmd,
+            command = %cmd,
             "spawned review process"
         );
 
@@ -161,6 +247,119 @@ mod tests {
             updated_at: Utc::now(),
         }
     }
+
+    // -- TemplateContext unit tests ----------------------------------------
+
+    #[test]
+    fn interpolate_replaces_all_variables() {
+        let job = make_job(1, None);
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        let cmd = ctx.interpolate(
+            "{pr_url} {repo} {pr_number} {head_sha} {worktree_path} {job_id} {output_path}",
+        );
+        assert_eq!(
+            cmd,
+            format!(
+                "https://github.com/owner/repo/pull/1 owner/repo 1 abc123 /tmp/worktree 1 {}",
+                worktree.join("REVIEW.md").display()
+            )
+        );
+    }
+
+    #[test]
+    fn interpolate_no_variables_passthrough() {
+        let job = make_job(1, None);
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        let cmd = ctx.interpolate("echo hello");
+        assert_eq!(cmd, "echo hello");
+    }
+
+    #[test]
+    fn interpolate_unknown_variables_left_intact() {
+        let job = make_job(1, None);
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        let cmd = ctx.interpolate("echo {unknown_var}");
+        assert_eq!(cmd, "echo {unknown_var}");
+    }
+
+    #[test]
+    fn interpolate_partial_variables() {
+        let job = make_job(1, None);
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        let cmd = ctx.interpolate("review --pr {pr_number} --sha {head_sha}");
+        assert_eq!(cmd, "review --pr 1 --sha abc123");
+    }
+
+    #[test]
+    fn interpolate_repeated_variables() {
+        let job = make_job(1, None);
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        let cmd = ctx.interpolate("{job_id}-{job_id}");
+        assert_eq!(cmd, "1-1");
+    }
+
+    #[test]
+    fn env_vars_all_present() {
+        let job = make_job(1, None);
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        let env_vars = ctx.env_vars();
+        assert_eq!(env_vars.len(), 7);
+
+        let find = |key: &str| -> String {
+            env_vars
+                .iter()
+                .find(|(k, _)| k == key)
+                .unwrap_or_else(|| panic!("{key} not found"))
+                .1
+                .clone()
+        };
+
+        assert_eq!(
+            find("REVIEWQ_PR_URL"),
+            "https://github.com/owner/repo/pull/1"
+        );
+        assert_eq!(find("REVIEWQ_REPO"), "owner/repo");
+        assert_eq!(find("REVIEWQ_PR_NUMBER"), "1");
+        assert_eq!(find("REVIEWQ_HEAD_SHA"), "abc123");
+        assert_eq!(find("REVIEWQ_WORKTREE_PATH"), "/tmp/worktree");
+        assert_eq!(find("REVIEWQ_JOB_ID"), "1");
+        assert_eq!(
+            find("REVIEWQ_OUTPUT_PATH"),
+            worktree.join("REVIEW.md").display().to_string()
+        );
+    }
+
+    #[test]
+    fn interpolate_with_job_specific_command() {
+        let job = make_job(1, Some("custom-review {pr_url} --out {output_path}"));
+        let worktree = Path::new("/tmp/worktree");
+        let ctx = TemplateContext::new(&job, worktree);
+
+        // Job-level command should also be interpolated.
+        let raw_cmd = job.command.as_deref().unwrap();
+        let cmd = ctx.interpolate(raw_cmd);
+        assert_eq!(
+            cmd,
+            format!(
+                "custom-review https://github.com/owner/repo/pull/1 --out {}",
+                worktree.join("REVIEW.md").display()
+            )
+        );
+    }
+
+    // -- CommandExecutor integration tests ----------------------------------
 
     #[tokio::test]
     async fn execute_echo_command() {

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -19,6 +19,7 @@ pub async fn spawn_in_group(
     workdir: &Path,
     stdout_path: &Path,
     stderr_path: &Path,
+    env_vars: &[(String, String)],
 ) -> Result<(tokio::process::Child, u32)> {
     let stdout_file = std::fs::File::create(stdout_path).map_err(|e| {
         ReviewqError::Process(format!(
@@ -41,6 +42,7 @@ pub async fn spawn_in_group(
         Command::new("sh")
             .args(["-c", command])
             .current_dir(workdir)
+            .envs(env_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())))
             .stdout(stdout_file)
             .stderr(stderr_file)
             .pre_exec(|| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -168,6 +168,67 @@ async fn executor_runs_command_and_captures_output() {
 }
 
 #[tokio::test]
+async fn executor_interpolates_template_variables() {
+    let tmp = TempDir::new().expect("temp dir");
+    let output_dir = tmp.path().join("output");
+    let worktree = tmp.path().join("worktree");
+    std::fs::create_dir_all(&worktree).expect("create worktree dir");
+
+    // Command writes interpolated template values into REVIEW.md.
+    let cmd =
+        r#"printf '%s\n%s\n%s\n%s' '{pr_url}' '{repo}' '{pr_number}' '{head_sha}' > REVIEW.md"#;
+    let executor = CommandExecutor::new(cmd.into(), CancelConfig::default(), output_dir);
+
+    let job = make_test_job(7, None);
+    let result = executor.execute(&job, &worktree).await.expect("execute");
+
+    assert_eq!(result.exit_code, 0);
+    let content = result.review_markdown.expect("REVIEW.md should exist");
+    assert!(
+        content.contains("https://github.com/owner/repo/pull/1"),
+        "pr_url not interpolated: {content}"
+    );
+    assert!(
+        content.contains("owner/repo"),
+        "repo not interpolated: {content}"
+    );
+    assert!(
+        content.contains("abc123"),
+        "head_sha not interpolated: {content}"
+    );
+}
+
+#[tokio::test]
+async fn executor_sets_environment_variables() {
+    let tmp = TempDir::new().expect("temp dir");
+    let output_dir = tmp.path().join("output");
+    let worktree = tmp.path().join("worktree");
+    std::fs::create_dir_all(&worktree).expect("create worktree dir");
+
+    // Command echoes REVIEWQ_* env vars into REVIEW.md.
+    let cmd = r#"printf '%s\n%s\n%s\n%s' "$REVIEWQ_PR_URL" "$REVIEWQ_REPO" "$REVIEWQ_PR_NUMBER" "$REVIEWQ_HEAD_SHA" > REVIEW.md"#;
+    let executor = CommandExecutor::new(cmd.into(), CancelConfig::default(), output_dir);
+
+    let job = make_test_job(8, None);
+    let result = executor.execute(&job, &worktree).await.expect("execute");
+
+    assert_eq!(result.exit_code, 0);
+    let content = result.review_markdown.expect("REVIEW.md should exist");
+    assert!(
+        content.contains("https://github.com/owner/repo/pull/1"),
+        "REVIEWQ_PR_URL not set: {content}"
+    );
+    assert!(
+        content.contains("owner/repo"),
+        "REVIEWQ_REPO not set: {content}"
+    );
+    assert!(
+        content.contains("abc123"),
+        "REVIEWQ_HEAD_SHA not set: {content}"
+    );
+}
+
+#[tokio::test]
 async fn executor_reads_review_md_from_worktree() {
     let tmp = TempDir::new().expect("temp dir");
     let output_dir = tmp.path().join("output");


### PR DESCRIPTION
## Summary
- Add template variable interpolation for `runner.command`: `{pr_url}`, `{repo}`, `{pr_number}`, `{head_sha}`, `{worktree_path}`, `{job_id}`, `{output_path}`
- Inject `REVIEWQ_*` environment variables into child processes so scripts can access job context programmatically
- Add `warn_unknown_variables()` to log warnings for unrecognized `{identifier}` patterns post-interpolation

## Changes
| File | Description |
|------|-------------|
| `src/executor.rs` | Add `TemplateContext` struct (single source of truth for all template/env values), `warn_unknown_variables()`, update `execute()` to interpolate before spawning |
| `src/runner/process.rs` | Add `env_vars` parameter to `spawn_in_group()`, apply via `.envs()` on Command |
| `tests/integration.rs` | Add 2 integration tests for template interpolation and env var passthrough |

## Test plan
- [x] 7 unit tests for `TemplateContext` (all variables, passthrough, unknown, partial, repeated, env vars, job-specific command)
- [x] 2 integration tests (template interpolation end-to-end, env var passthrough end-to-end)
- [x] `make all` passes (fmt + clippy + test): 97 unit + 7 integration tests green
- [x] Codex code review LGTM (session `019c80f5-12e2-7c62-8881-a037d465acf0`)