### PR TITLE
chore: add harness-engineering workflow enforcement hooks

### DIFF
--- a/.claude/commands/config-edit.md
+++ b/.claude/commands/config-edit.md
@@ -1,0 +1,42 @@
+---
+description: Unlock protected config file edits for this session (Cargo.toml, Makefile, CI workflows, etc.)
+---
+
+# /config-edit — approve config edits for this session
+
+Protected config files (`Cargo.toml`, `Cargo.lock`, `Makefile`, `clippy.toml`,
+`rustfmt.toml`, `deny.toml`, `rust-toolchain.toml`, `.gitignore`, and
+`.github/workflows/**`) are locked by default by
+`.claude/hooks/config-protect-gate.sh`.
+
+This command sets a session-scoped marker that unblocks edits to those
+files for the remainder of the current Claude Code session. The marker
+is stored under `.claude/.session/<session_id>/config-edit-approved`
+and is automatically discarded when the session ends.
+
+## When to use
+
+- You intentionally want to add a dependency to `Cargo.toml`.
+- You are bumping a tool version in `rust-toolchain.toml`.
+- You are patching CI in `.github/workflows/`.
+- You are tightening linter strictness in `clippy.toml`.
+
+Do **not** use this to silence gate warnings — if the hook is wrong,
+fix the hook in a `chore/` worktree instead.
+
+## What Claude does on this command
+
+```bash
+SID=$(ls -t "$CLAUDE_PROJECT_DIR/.claude/.session/" 2>/dev/null | head -1)
+if [[ -z "$SID" ]]; then
+    echo "No active session dir. Try editing any file first, then retry."
+    exit 1
+fi
+mkdir -p "$CLAUDE_PROJECT_DIR/.claude/.session/$SID"
+touch "$CLAUDE_PROJECT_DIR/.claude/.session/$SID/config-edit-approved"
+echo "✅ Config-edit approved for session $SID."
+echo "   The marker will be discarded automatically at session end."
+```
+
+After the marker is set, retry the blocked edit and the
+`config-protect-gate.sh` will allow it.

--- a/.claude/commands/harness-status.md
+++ b/.claude/commands/harness-status.md
@@ -1,0 +1,84 @@
+---
+description: Show the current harness-engineering gate state (markers + recent hook log)
+---
+
+# /harness-status — inspect the enforcement layer
+
+Prints:
+
+1. The session id currently in use.
+2. Every marker file under `.claude/.session/<session_id>/` — each one
+   corresponds to a phase of the workflow that has been completed.
+3. The last 20 hook decisions from `hook-log.jsonl` — so you can see
+   exactly which gates fired and why.
+4. Which gates are currently passing and which would still block.
+
+Useful to run at any time to answer *"why did that hook block me?"*
+and *"what do I still need to do before I can commit?"*.
+
+## What Claude does on this command
+
+```bash
+# Pick the freshest session dir.
+ROOT="$CLAUDE_PROJECT_DIR/.claude/.session"
+SID=$(ls -t "$ROOT" 2>/dev/null | head -1)
+if [[ -z "$SID" ]]; then
+    echo "No session state yet — no hook has fired this session."
+    exit 0
+fi
+DIR="$ROOT/$SID"
+
+echo "## Session"
+echo "  id:  $SID"
+echo "  dir: $DIR"
+echo
+
+echo "## Markers (workflow phases completed)"
+if [[ -d "$DIR" ]]; then
+    for f in "$DIR"/*; do
+        [[ -f "$f" ]] || continue
+        base=$(basename "$f")
+        case "$base" in
+            hook-log.jsonl|stop-gate-check.log) continue ;;
+        esac
+        printf "  ✅ %s\n" "$base"
+    done
+fi
+echo
+
+echo "## Recent hook decisions (last 20)"
+if [[ -f "$DIR/hook-log.jsonl" ]]; then
+    tail -20 "$DIR/hook-log.jsonl" | jq -r '
+        "[\(.ts)] \(.hook) -> \(.decision): \(.reason)"
+    '
+else
+    echo "  (no log yet)"
+fi
+echo
+
+echo "## Commit readiness"
+need=()
+[[ -f "$DIR/agents-md-read" ]]  || need+=("Read AGENTS.md")
+[[ -f "$DIR/skill-invoked" ]]   || need+=("Invoke any Skill()")
+if [[ -f "$DIR/rust-files-edited" ]]; then
+    [[ -f "$DIR/tdd-tests-written" ]] || need+=("Write tests or invoke rust-testing/tdd-workflow skill")
+    [[ -f "$DIR/rust-review-done" ]]  || need+=("Run /rust-review or Agent(rust-reviewer)")
+fi
+if ls "$DIR"/skill:reviewq-e2e >/dev/null 2>&1 || [[ -f "$DIR/e2e-done" ]]; then
+    :
+else
+    if [[ -f "$DIR/tui-files-edited" ]]; then
+        need+=("Invoke reviewq-e2e skill (TUI changes detected)")
+    fi
+fi
+
+if [[ ${#need[@]} -eq 0 ]]; then
+    echo "  ✅ All visible gates should pass. (commit-gate will still run"
+    echo "     cargo fmt --check / clippy / test on the actual commit.)"
+else
+    echo "  ❌ Still required before commit-gate will allow a commit:"
+    for item in "${need[@]}"; do
+        echo "     - $item"
+    done
+fi
+```

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,96 @@
+# reviewq Claude Code Hooks
+
+Mechanical enforcement of the AGENTS.md + `.claude/rules/skills.md`
+workflow. The rules were soft guidance and Claude skipped them; these
+hooks make the most important steps **blocking**.
+
+## Layout
+
+```
+.claude/hooks/
+├── lib/
+│   └── common.sh                   # shared bash helpers (session dir, jq, block)
+├── worktree-gate.sh                # PreToolUse  Edit/Write — worktree required
+├── agents-md-gate.sh               # PreToolUse  Edit/Write — AGENTS.md must be read
+├── skill-routing-gate.sh           # PreToolUse  Edit/Write on *.rs — Skill() required
+├── commit-gate.sh                  # PreToolUse  Bash(git commit) — fmt/clippy/test + markers
+├── mark-post-tool.sh               # PostToolUse Read/Skill/Agent — sets session markers
+└── README.md                       # this file
+```
+
+Markers are touched under `.claude/.session/<session_id>/` and are
+namespaced per session, so they do not leak between runs and do not
+need explicit cleanup.
+
+## Enforcement Matrix
+
+| Phase | Rule source | Gate | Block condition |
+|-------|-------------|------|-----------------|
+| Workspace | AGENTS.md → Git Workflow | `worktree-gate.sh` | Edit target is inside the main reviewq repo and **not** under `.worktree/**` |
+| Planning | CLAUDE.md → delegates all rules to AGENTS.md | `agents-md-gate.sh` | Any Edit/Write before `AGENTS.md` was Read this session |
+| Implement | `.claude/rules/skills.md` Phase 3 | `skill-routing-gate.sh` | Edit of any `*.rs` file before **any** Skill was invoked this session |
+| Commit — verification | AGENTS.md → Build & Quality | `commit-gate.sh` | `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` failing |
+| Commit — review | `.claude/rules/skills.md` Phase 5 | `commit-gate.sh` | Rust files staged but no `rust-review-done` marker for this session |
+| Commit — TUI e2e | `.claude/rules/skills.md` Phase 4 | `commit-gate.sh` | `src/tui/**` files staged but no `e2e-done` marker |
+| Commit — worktree | AGENTS.md → Git Workflow | `commit-gate.sh` | `git commit` run from outside a `.worktree/` directory |
+
+## Escape hatches
+
+Only **two** bypasses exist, both intentional and scoped:
+
+1. `worktree-gate.sh` allows edits under `$CLAUDE_PROJECT_DIR/.claude/hooks/**`
+   and `.claude/.session/**`. Without this, the hooks could not be
+   bootstrapped or patched (you would be unable to fix the very gate
+   that is blocking you).
+2. `agents-md-gate.sh` applies the same two-path allow-list for the same
+   reason.
+
+There is **no** environment variable, CLI flag, or config switch that
+disables the gates. The global CLAUDE.md forbids `--no-verify` and any
+hook bypass. If a gate is wrong, fix the hook — do not bypass it.
+
+## Soft-fail policy
+
+All hooks source `lib/common.sh`, which installs an `EXIT` trap that
+converts any unexpected non-zero exit (unset variable, `jq` error, etc.)
+into `exit 0`. Blocks are therefore **always explicit** — a buggy hook
+can never stall legitimate work. The tradeoff is that a silently broken
+hook no-ops; run `bash -n <hook>.sh` and the self-test below after any
+edit to catch this.
+
+## Self-test (no live session required)
+
+Each hook can be exercised locally by feeding it a synthetic JSON
+payload on stdin and checking the exit code + stderr:
+
+```bash
+# Should allow (Rust edit under .worktree/**):
+echo '{
+  "session_id": "test",
+  "tool_name": "Edit",
+  "tool_input": {"file_path": "/Users/me/reviewq/.worktree/foo/src/lib.rs"},
+  "cwd": "/Users/me/reviewq/.worktree/foo"
+}' | .claude/hooks/worktree-gate.sh; echo "exit=$?"
+
+# Should block (Rust edit in main tree):
+echo '{
+  "session_id": "test",
+  "tool_name": "Edit",
+  "tool_input": {"file_path": "/Users/me/reviewq/src/lib.rs"},
+  "cwd": "/Users/me/reviewq"
+}' | CLAUDE_PROJECT_DIR=/Users/me/reviewq .claude/hooks/worktree-gate.sh; echo "exit=$?"
+```
+
+A curated set of these cases lives in `.claude/hooks/tests/` (see
+`run-tests.sh`). CI should invoke it via `make test-hooks`.
+
+## Adding a new gate
+
+1. Create `<name>-gate.sh` following the pattern of the existing hooks:
+   source `lib/common.sh`, call `reviewq_require_jq`, read input via
+   `reviewq_read_input`, check a marker or a condition, and call
+   `reviewq_block "…"` to stop the tool call.
+2. Make it executable: `chmod +x .claude/hooks/<name>-gate.sh`.
+3. Wire it up under the right matcher in `.claude/settings.json`.
+4. Add a row to the Enforcement Matrix above.
+5. Add positive and negative test cases to `.claude/hooks/tests/`.

--- a/.claude/hooks/agents-md-gate.sh
+++ b/.claude/hooks/agents-md-gate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PreToolUse gate: require that AGENTS.md has been read before any edit.
+#
+# Rationale: AGENTS.md is the authoritative source for the build, git, and
+# review workflow. The project CLAUDE.md delegates every rule to it. Past
+# sessions have shown Claude will skip it unless the workflow is mechanically
+# enforced, so we require a session-scoped marker before allowing any edit.
+#
+# The marker is set by mark-post-tool.sh when Claude reads AGENTS.md via the
+# Read tool. It lives in .claude/.session/<session_id>/agents-md-read and is
+# automatically discarded at the end of the session.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit|NotebookEdit) ;;
+    *) exit 0 ;;
+esac
+
+# Bootstrap: allow edits that only touch the hook infrastructure or the
+# session directory, so we can install/patch the gate itself.
+file_path=$(reviewq_jq '.tool_input.file_path')
+project_dir=$(reviewq_project_dir)
+case "$file_path" in
+    "$project_dir"/.claude/hooks/*|"$project_dir"/.claude/.session/*) exit 0 ;;
+    .claude/hooks/*|.claude/.session/*) exit 0 ;;
+esac
+
+if reviewq_has_mark agents-md-read; then
+    exit 0
+fi
+
+reviewq_block "AGENTS.md has not been read in this session.
+
+The project CLAUDE.md points to AGENTS.md as the single source of truth
+for the build, git-worktree, quality, and review workflow. Every session
+must consult it before editing code.
+
+Fix:
+  Use the Read tool on $project_dir/AGENTS.md.
+  A post-tool hook will record the read and unblock this gate."

--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# PreToolUse gate: before `git commit` succeeds, require that the
+# verification loop is green AND that a rust-review has been performed in
+# this session (if any Rust source files changed).
+#
+# Rule (AGENTS.md → Build & Quality, Git Workflow):
+#   "REQUIRED: Run before completing any work — make all (format + lint + test)"
+#   ".claude/rules/skills.md → Phase 5: Every code change → /rust-review"
+#
+# Policy:
+#   1. Only fire when the Bash command actually runs `git commit` (and not
+#      e.g. `git commit-tree`, `git commit --help`, or `echo 'git commit'`).
+#   2. Require `cargo fmt --check`, `cargo clippy --all-targets -D warnings`
+#      and `cargo test` to all pass in the commit's worktree.
+#   3. If any staged .rs file changed in this commit, require the marker
+#      `rust-review-done` to exist (set when the rust-reviewer agent ran
+#      in this session). Doc-only commits skip this check.
+#   4. Block with a detailed fix message on any failure.
+#
+# Internal failures (missing tools, parse errors) fall through to allow —
+# see lib/common.sh.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+[[ "$tool_name" != "Bash" ]] && exit 0
+
+cmd=$(reviewq_jq '.tool_input.command')
+[[ -z "$cmd" ]] && exit 0
+
+# Match `git commit` as a subcommand. We want to catch:
+#   git commit -m "..."
+#   git -c foo=bar commit ...
+#   cd x && git commit ...
+# but NOT:
+#   git commit-tree ...
+#   git commit --help
+#   echo "git commit ..."
+#   git log --grep='git commit'
+#
+# Heuristic: require the literal token "git commit" (space-separated) and
+# NOT be inside quotes. Good enough in practice; the gate is conservative.
+if ! printf '%s' "$cmd" | grep -Eq '(^|[^a-zA-Z_-])git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*commit([[:space:]]|$)'; then
+    exit 0
+fi
+# Skip benign subcommands.
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+commit(-tree|[[:space:]]+--help|[[:space:]]+-h([[:space:]]|$))'; then
+    exit 0
+fi
+# Skip quoted / commented uses (echo, grep, log).
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]])(echo|printf|grep|rg|awk|sed)([[:space:]]|$)'; then
+    # Could still be a legit `foo && git commit`; only bail if the only
+    # verb is one of the above.
+    if ! printf '%s' "$cmd" | grep -Eq '(&&|;|\|\|)[[:space:]]*git[[:space:]]+commit'; then
+        exit 0
+    fi
+fi
+
+# cwd from the hook input is where the Bash tool will execute the command,
+# which is where we need to run `cargo`.
+cwd=$(reviewq_jq '.cwd')
+[[ -z "$cwd" ]] && cwd=$(reviewq_project_dir)
+[[ ! -d "$cwd" ]] && exit 0
+
+# The commit must happen inside a worktree. Worktree-gate covers edits but
+# not commits, so we enforce it here too.
+case "$cwd" in
+    */.worktree/*) ;;
+    *)
+        reviewq_block "git commit attempted outside a .worktree/ directory.
+
+AGENTS.md forbids committing from the main worktree. Create a feature
+branch worktree and retry the commit there:
+  git worktree add -b <type>/<slug> .worktree/<type>-<slug>
+  cd .worktree/<type>-<slug>"
+        ;;
+esac
+
+# ---- collect staged file list once, for downstream checks ---------------
+staged=$(git -C "$cwd" diff --cached --name-only 2>/dev/null || true)
+if [[ -z "$staged" ]]; then
+    # No staged changes — let git itself complain; nothing for us to gate.
+    exit 0
+fi
+rust_staged=$(printf '%s\n' "$staged" | grep -E '\.rs$' || true)
+
+# ---- 1. cargo fmt --check -----------------------------------------------
+if ! (cd "$cwd" && cargo fmt --check >/tmp/reviewq-gate-fmt.log 2>&1); then
+    log=$(head -50 /tmp/reviewq-gate-fmt.log)
+    reviewq_block "cargo fmt --check FAILED.
+
+Run inside the worktree:
+  cargo fmt
+
+Then stage the changes and retry the commit.
+
+--- first 50 lines of fmt output ---
+$log"
+fi
+
+# ---- 2. cargo clippy -----------------------------------------------------
+if ! (cd "$cwd" && cargo clippy --all-targets -- -D warnings >/tmp/reviewq-gate-clippy.log 2>&1); then
+    log=$(tail -60 /tmp/reviewq-gate-clippy.log)
+    reviewq_block "cargo clippy --all-targets -- -D warnings FAILED.
+
+Fix the warnings and retry the commit. Use:
+  /rust-build     (invokes rust-build-resolver for incremental fixes)
+
+--- last 60 lines of clippy output ---
+$log"
+fi
+
+# ---- 3. cargo test -------------------------------------------------------
+if ! (cd "$cwd" && cargo test --quiet >/tmp/reviewq-gate-test.log 2>&1); then
+    log=$(tail -80 /tmp/reviewq-gate-test.log)
+    reviewq_block "cargo test FAILED.
+
+Fix the failing tests and retry the commit. AGENTS.md requires 'make all'
+to pass before every commit.
+
+--- last 80 lines of test output ---
+$log"
+fi
+
+# ---- 4. rust-review marker (only when .rs files are staged) -------------
+if [[ -n "$rust_staged" ]] && ! reviewq_has_mark rust-review-done; then
+    file_count=$(printf '%s\n' "$rust_staged" | wc -l | tr -d ' ')
+    reviewq_block "$file_count staged Rust file(s) but no rust-review has run in this session.
+
+.claude/rules/skills.md requires a /rust-review pass on every code change
+before commit.
+
+Fix: invoke the rust-reviewer via the Agent tool, or run the slash command:
+  /rust-review
+
+A post-tool hook will set the rust-review-done marker when the agent
+finishes, unblocking this gate. Staged Rust files:
+$(printf '  %s\n' $rust_staged)"
+fi
+
+# ---- 5. e2e marker (only when src/tui/** files are staged) --------------
+tui_staged=$(printf '%s\n' "$staged" | grep -E '^src/tui/' || true)
+if [[ -n "$tui_staged" ]] && ! reviewq_has_mark e2e-done; then
+    reviewq_block "TUI files staged but reviewq-e2e has not run this session.
+
+.claude/rules/skills.md → Phase 4: 'TUI behavior changes (src/tui/**) → reviewq-e2e'
+
+Fix: run the e2e workflow, then retry the commit.
+  Skill(reviewq-e2e)
+
+Once the e2e run marker is set, this gate will unblock."
+fi
+
+# All gates passed.
+exit 0

--- a/.claude/hooks/config-protect-gate.sh
+++ b/.claude/hooks/config-protect-gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# PreToolUse gate: require explicit confirmation before editing protected
+# config files. This is the Edit/Write counterpart to the Bash redirect
+# check in safety-gate.sh.
+#
+# Rationale:
+#   nyosegawa harness-engineering:
+#     "PreToolUse Hook blocks edits to config files (.eslintrc, biome.json,
+#      Cargo.toml, etc.)"
+#   ignission hunting-to-farming:
+#     "pre-edit-guard: Prevents modification of linter configs, hook
+#      scripts themselves"
+#
+# Protected files:
+#   Cargo.toml, Cargo.lock  — dependency drift
+#   Makefile               — build pipeline
+#   rustfmt.toml, .rustfmt.toml, clippy.toml — lint strictness
+#   deny.toml, rust-toolchain.toml — toolchain / security
+#   .github/workflows/**   — CI gates
+#   .gitignore             — can hide generated artifacts
+#
+# Policy:
+#   Always block. The user can unblock by explicitly telling the agent
+#   to edit the file (which will surface in conversation), and the hook
+#   will re-run on the retry and block again unless the session has the
+#   `config-edit-approved` marker, which is set only by a `/config-edit`
+#   slash command the user runs manually.
+#
+#   In other words: the only way to edit protected configs is for the
+#   HUMAN to opt in once per session. This is intentional friction.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit|NotebookEdit) ;;
+    *) exit 0 ;;
+esac
+
+file_path=$(reviewq_jq '.tool_input.file_path')
+[[ -z "$file_path" ]] && exit 0
+
+# Extract basename for simple comparisons, and keep the full path for
+# directory-scoped checks (e.g. .github/workflows).
+base=$(basename "$file_path")
+
+protected_basenames=(
+    "Cargo.toml"
+    "Cargo.lock"
+    "Makefile"
+    "rustfmt.toml"
+    ".rustfmt.toml"
+    "clippy.toml"
+    "deny.toml"
+    "rust-toolchain.toml"
+    "rust-toolchain"
+    ".gitignore"
+)
+
+is_protected=0
+for name in "${protected_basenames[@]}"; do
+    if [[ "$base" == "$name" ]]; then
+        is_protected=1
+        break
+    fi
+done
+
+# Directory-scoped protection: any file under .github/workflows/**
+case "$file_path" in
+    *"/.github/workflows/"*) is_protected=1 ;;
+esac
+
+[[ "$is_protected" -eq 0 ]] && exit 0
+
+# User escape hatch: a marker set by the /config-edit slash command (or
+# a manual touch) unlocks config edits for the remainder of the session.
+if reviewq_has_mark config-edit-approved; then
+    reviewq_log_event allow "config edit approved this session: $file_path"
+    exit 0
+fi
+
+reviewq_block "Edit of protected config file '$file_path' requires explicit approval.
+
+Protected files (Cargo.toml / Cargo.lock / Makefile / clippy.toml /
+rustfmt.toml / deny.toml / rust-toolchain.toml / .gitignore /
+.github/workflows/**) are locked by default because silent changes to
+them cause dependency drift, CI pipeline regressions, or loosened
+linter strictness that gets caught weeks later.
+
+Fix:
+  Have the human user run:
+    /config-edit
+  to set the 'config-edit-approved' marker for this session. The marker
+  is session-scoped and expires when the session ends.
+
+  If no /config-edit command exists yet, the user can manually touch:
+    .claude/.session/<session_id>/config-edit-approved"

--- a/.claude/hooks/lib/common.sh
+++ b/.claude/hooks/lib/common.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Shared helpers for all reviewq Claude Code hooks.
+#
+# Source this at the top of every hook script:
+#     . "$(dirname "$0")/lib/common.sh"
+#
+# All hooks read a single JSON object from stdin (the tool call payload).
+# Exit codes:
+#   0 = allow the tool call (or: success / no-op for PostToolUse)
+#   2 = block the tool call with a message printed to stderr
+#   *  = treated as an error — we avoid this so a buggy hook cannot stall
+#         legitimate work. On internal errors we print to stderr and exit 0.
+#
+# Session-scoped marker files live under:
+#     $CLAUDE_PROJECT_DIR/.claude/.session/<session_id>/<marker>
+#
+# The directory is gitignored and namespaced per session, so it does not
+# need to be reset explicitly.
+
+set -u
+
+# --- soft-fail trap --------------------------------------------------------
+# If anything below blows up (unset var, jq error, missing dep), fall through
+# to exit 0 so we never wedge the developer. Blocks are ALWAYS explicit via
+# reviewq_block().
+reviewq_soft_fail() {
+    local status=$?
+    if [[ $status -ne 0 && $status -ne 2 ]]; then
+        echo "[reviewq-hook] internal error (status=$status) in ${BASH_SOURCE[1]:-hook} — allowing" >&2
+        exit 0
+    fi
+}
+trap reviewq_soft_fail EXIT
+
+# --- input capture ---------------------------------------------------------
+# Read stdin JSON once and expose it as REVIEWQ_INPUT.
+reviewq_read_input() {
+    if [[ -z "${REVIEWQ_INPUT:-}" ]]; then
+        REVIEWQ_INPUT=$(cat)
+    fi
+    export REVIEWQ_INPUT
+}
+
+# Extract a field from the input JSON. Usage: reviewq_jq '.tool_name'
+reviewq_jq() {
+    printf '%s' "$REVIEWQ_INPUT" | jq -r "$1 // empty" 2>/dev/null || true
+}
+
+# --- project paths ---------------------------------------------------------
+reviewq_project_dir() {
+    # Prefer the env var Claude Code sets; fall back to the cwd from JSON.
+    if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+        printf '%s' "$CLAUDE_PROJECT_DIR"
+    else
+        reviewq_jq '.cwd'
+    fi
+}
+
+# Session state directory (created on demand, gitignored).
+reviewq_session_dir() {
+    local sid
+    sid=$(reviewq_jq '.session_id')
+    if [[ -z "$sid" ]]; then
+        sid="unknown-session"
+    fi
+    local root
+    root=$(reviewq_project_dir)
+    local dir="$root/.claude/.session/$sid"
+    mkdir -p "$dir"
+    printf '%s' "$dir"
+}
+
+# Touch a marker file in the session dir. Usage: reviewq_mark agents-md-read
+reviewq_mark() {
+    local name="$1"
+    local dir
+    dir=$(reviewq_session_dir)
+    touch "$dir/$name"
+}
+
+# Test whether a marker exists. Usage: if reviewq_has_mark x; then ...
+reviewq_has_mark() {
+    local name="$1"
+    local dir
+    dir=$(reviewq_session_dir)
+    [[ -f "$dir/$name" ]]
+}
+
+# --- blocking --------------------------------------------------------------
+# Block the tool call with a message. Goes to stderr so Claude sees it.
+# Logs the block decision to hook-log.jsonl before exiting so we can audit
+# why the agent was stopped even if the stderr output is truncated.
+reviewq_block() {
+    local msg="$1"
+    # Best-effort log; never let logging failure affect the block.
+    reviewq_log_event block "$(printf '%s' "$msg" | head -1)" 2>/dev/null || true
+    echo "" >&2
+    echo "🛑 reviewq workflow gate blocked this action:" >&2
+    echo "" >&2
+    local line
+    while IFS= read -r line; do
+        echo "   $line" >&2
+    done <<< "$msg"
+    echo "" >&2
+    exit 2
+}
+
+# --- helpers ---------------------------------------------------------------
+# True if `jq` is available. We hard-require it; without jq the hooks cannot
+# parse the input JSON so they soft-fail open (see the EXIT trap above).
+reviewq_require_jq() {
+    command -v jq >/dev/null 2>&1 || {
+        echo "[reviewq-hook] 'jq' not found on PATH — hook will no-op" >&2
+        exit 0
+    }
+}
+
+# --- observability ---------------------------------------------------------
+# Append a structured event to the session's hook-log.jsonl. Used so we can
+# reconstruct *why* a given tool call was blocked or allowed after the fact
+# without re-running the session. Fields:
+#
+#   ts      — ISO-8601 UTC timestamp
+#   hook    — basename of the hook script
+#   tool    — tool_name from the input JSON
+#   decision — "allow" | "block" | "feedback" | "mark" | "info"
+#   reason  — short free-text
+#
+# Usage:
+#   reviewq_log_event allow "tool in worktree — no-op"
+#   reviewq_log_event block "destructive command: rm -rf /"
+reviewq_log_event() {
+    local decision="$1"
+    local reason="${2:-}"
+    local dir
+    dir=$(reviewq_session_dir) || return 0
+    local hook_name
+    hook_name=$(basename "${BASH_SOURCE[1]:-unknown}")
+    local tool
+    tool=$(reviewq_jq '.tool_name')
+    local ts
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    # Single-line JSONL so it's trivially grep/jq-able after the fact.
+    jq -nc \
+        --arg ts "$ts" \
+        --arg hook "$hook_name" \
+        --arg tool "$tool" \
+        --arg decision "$decision" \
+        --arg reason "$reason" \
+        '{ts:$ts, hook:$hook, tool:$tool, decision:$decision, reason:$reason}' \
+        >> "$dir/hook-log.jsonl" 2>/dev/null || true
+}
+
+# --- PostToolUse feedback injection ----------------------------------------
+# Emit a JSON object on stdout in the format Claude Code expects for
+# PostToolUse hooks that want to inject additional context back to the
+# agent. Reference: nyosegawa harness-engineering article.
+#
+#   reviewq_post_feedback "clippy warnings:\n..."
+#
+# The agent will see this text as part of the tool result and can self-
+# correct on the next turn. This is the "millisecond feedback loop" layer
+# at the heart of Harness Engineering.
+reviewq_post_feedback() {
+    local msg="$1"
+    jq -Rn --arg msg "$msg" '{
+        hookSpecificOutput: {
+            hookEventName: "PostToolUse",
+            additionalContext: $msg
+        }
+    }'
+}
+
+# --- Stop hook decision output ---------------------------------------------
+# Emit the Stop-hook JSON that blocks the agent from claiming "done".
+# Usage: reviewq_stop_block "cargo check failed: ..."
+reviewq_stop_block() {
+    local reason="$1"
+    jq -Rn --arg reason "$reason" '{
+        decision: "block",
+        reason: $reason
+    }'
+}

--- a/.claude/hooks/mark-post-tool.sh
+++ b/.claude/hooks/mark-post-tool.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# PostToolUse dispatcher: sets session-scoped marker files based on the
+# tool that just finished executing.
+#
+# Markers we maintain (all live under .claude/.session/<session_id>/):
+#
+#   agents-md-read       — Read tool was called with file_path matching
+#                          AGENTS.md. Unlocks agents-md-gate.sh.
+#
+#   skill-invoked        — Any Skill tool call. Unlocks
+#                          skill-routing-gate.sh for Rust source edits.
+#
+#   skill:<name>         — Per-skill marker for future fine-grained gates.
+#
+#   rust-review-done     — The rust-reviewer agent (via Agent/Task tool)
+#                          or the rust-review skill finished. Unlocks
+#                          the rust-review check in commit-gate.sh.
+#
+#   e2e-done             — reviewq-e2e skill was invoked. Unlocks the
+#                          TUI e2e check in commit-gate.sh.
+#
+#   tdd-tests-written    — tdd-workflow / rust-testing skill was invoked,
+#                          OR a test file has been edited this session.
+#                          Unlocks tdd-gate.sh.
+#
+#   tests-edited         — A test file (explicit path under tests/,
+#                          *_test.rs, or a file containing #[cfg(test)])
+#                          was edited.
+#
+#   rust-files-edited    — Any *.rs file was edited this session. Used by
+#                          stop-gate.sh to decide whether to run
+#                          `cargo check` on Stop.
+#
+# This hook is attached to PostToolUse with a broad matcher. It never
+# blocks (always exit 0) and its only side effect is `touch`-ing marker
+# files. Buggy marker logic therefore cannot stall legitimate work.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+
+# Helper: given a file path, mark rust-files-edited and tests-edited if
+# the path or its contents indicate a Rust file / test file.
+_mark_rust_file() {
+    local fp="$1"
+    [[ -z "$fp" ]] && return 0
+    case "$fp" in
+        *.rs) ;;
+        *) return 0 ;;
+    esac
+    reviewq_mark rust-files-edited
+    case "$fp" in
+        *_test.rs|*/tests/*|*/test_*.rs)
+            reviewq_mark tests-edited
+            reviewq_mark tdd-tests-written
+            return 0
+            ;;
+    esac
+    # Peek inside the file (if it exists) for in-file test markers.
+    if [[ -f "$fp" ]] && grep -qE '^\s*#\[(cfg\(test\)|test)' "$fp" 2>/dev/null; then
+        reviewq_mark tests-edited
+        reviewq_mark tdd-tests-written
+    fi
+}
+
+case "$tool_name" in
+    Read)
+        file_path=$(reviewq_jq '.tool_input.file_path')
+        case "$file_path" in
+            */AGENTS.md|AGENTS.md)
+                reviewq_mark agents-md-read
+                reviewq_log_event mark "agents-md-read set"
+                ;;
+        esac
+        ;;
+
+    Skill)
+        skill_name=$(reviewq_jq '.tool_input.skill')
+        reviewq_mark skill-invoked
+        if [[ -n "$skill_name" ]]; then
+            # Marker filenames cannot contain slashes; replace with `__`.
+            safe=$(printf '%s' "$skill_name" | tr '/:' '__')
+            reviewq_mark "skill:$safe"
+            case "$skill_name" in
+                reviewq-e2e)
+                    reviewq_mark e2e-done
+                    ;;
+                rust-testing|tdd-workflow)
+                    reviewq_mark tdd-tests-written
+                    ;;
+                rust-review)
+                    reviewq_mark rust-review-done
+                    ;;
+            esac
+            reviewq_log_event mark "skill:$skill_name marker set"
+        fi
+        ;;
+
+    Agent|Task)
+        subagent=$(reviewq_jq '.tool_input.subagent_type')
+        case "$subagent" in
+            rust-reviewer)
+                reviewq_mark rust-review-done
+                reviewq_log_event mark "rust-review-done set via Agent(rust-reviewer)"
+                ;;
+            tdd-guide)
+                reviewq_mark tdd-tests-written
+                reviewq_log_event mark "tdd-tests-written set via Agent(tdd-guide)"
+                ;;
+        esac
+        ;;
+
+    Write|Edit|MultiEdit)
+        file_path=$(reviewq_jq '.tool_input.file_path')
+        _mark_rust_file "$file_path"
+        ;;
+esac
+
+exit 0

--- a/.claude/hooks/post-edit-rust.sh
+++ b/.claude/hooks/post-edit-rust.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# PostToolUse feedback loop: run rustfmt on the just-edited Rust file and
+# inject any formatting diff back into the agent's context via the
+# hookSpecificOutput.additionalContext JSON channel.
+#
+# Rationale (from nyosegawa harness-engineering-best-practices-2026):
+#
+#   "Feedback Loop Speed Hierarchy:
+#     1. Milliseconds (PostToolUse): Formatter auto-executes; agent
+#        unaware of violation
+#     2. Seconds (pre-commit): Linter + type checker block commit
+#     3. Minutes (CI): Full test suite, deep analysis
+#    Migrate checks upward whenever possible."
+#
+# This hook is the millisecond layer for Rust. `rustfmt --check` on a
+# single file returns in ~50ms after warmup, which is fast enough to run
+# on every Edit/Write without meaningfully slowing the agent loop.
+#
+# Output format: stdout JSON per Claude Code PostToolUse contract so the
+# feedback is injected as *context*, not as a blocking error. The agent
+# sees it on the next turn and self-corrects. Blocks happen later, at
+# commit-gate time.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+file_path=$(reviewq_jq '.tool_input.file_path')
+[[ -z "$file_path" ]] && exit 0
+
+# Only Rust files.
+case "$file_path" in
+    *.rs) ;;
+    *) exit 0 ;;
+esac
+
+# Skip hook scripts directory; they are shell, not Rust.
+project_dir=$(reviewq_project_dir)
+case "$file_path" in
+    "$project_dir"/.claude/*) exit 0 ;;
+esac
+
+[[ ! -f "$file_path" ]] && exit 0
+
+# Mark that at least one Rust source file has been edited this session.
+# The Stop hook uses this to decide whether to run `cargo check`.
+reviewq_mark rust-files-edited
+
+# Detect test-flavored files so the TDD gate knows they exist.
+case "$file_path" in
+    *_test.rs|*/tests/*|*/test_*.rs)
+        reviewq_mark tests-edited
+        reviewq_mark tdd-tests-written
+        ;;
+    *)
+        # Also detect in-file tests via #[cfg(test)] or #[test].
+        if grep -qE '^\s*#\[(cfg\(test\)|test)' "$file_path" 2>/dev/null; then
+            reviewq_mark tests-edited
+            reviewq_mark tdd-tests-written
+        fi
+        ;;
+esac
+
+# Run rustfmt in check mode. Returns 0 if already formatted, 1 if a diff
+# would be applied. We explicitly want the diff, not the auto-fix, so the
+# agent sees *what* changed rather than silently rewriting.
+if ! command -v rustfmt >/dev/null 2>&1; then
+    reviewq_log_event info "rustfmt not on PATH — skipping auto-feedback"
+    exit 0
+fi
+
+# rustfmt needs the edition; read from Cargo.toml or default to 2024.
+edition="2024"
+if [[ -f "$project_dir/Cargo.toml" ]]; then
+    found_edition=$(grep -E '^edition[[:space:]]*=' "$project_dir/Cargo.toml" | head -1 | sed -E 's/^edition[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+    if [[ -n "$found_edition" ]]; then
+        edition="$found_edition"
+    fi
+fi
+
+diff_output=$(rustfmt --edition "$edition" --check "$file_path" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+    reviewq_log_event allow "rustfmt clean on $file_path"
+    exit 0
+fi
+
+# Truncate the diff so we don't spam the context window.
+short_diff=$(printf '%s\n' "$diff_output" | head -120)
+msg=$(printf 'rustfmt would reformat %s — please run `cargo fmt` or apply these changes manually before commit:\n\n%s' \
+    "$file_path" "$short_diff")
+
+reviewq_log_event feedback "rustfmt diff injected for $file_path"
+reviewq_post_feedback "$msg"
+exit 0

--- a/.claude/hooks/procrastination-gate.sh
+++ b/.claude/hooks/procrastination-gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# PreToolUse gate: block Write / Edit operations whose new content
+# contains procrastination language ("TODO later", "FIXME: fix in next
+# iteration", "後で対応", …).
+#
+# Rationale (from ignission's "hunting to farming" article):
+#
+#   "pre-bash-guard detects patterns like '次回対応' (next time) /
+#    '今後改善' (future improvement). Then enforces: either fix now OR
+#    create GitHub Issue first, then reply."
+#
+# This is the coarse Claude-Code equivalent. We use simple case-insensitive
+# substring matching against well-known procrastination phrases. The
+# agent can still defer legitimately by creating a real GitHub issue and
+# referencing it in a comment (e.g. `// see #123`), which will bypass the
+# pattern check because the phrase is replaced with a concrete pointer.
+#
+# We only scan the *new* content being written (new_string for Edit,
+# content for Write). Existing file content is never checked, so
+# legacy TODOs aren't flagged.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+# Concat all the "new content" fields from the tool input so we can grep
+# them in one pass. For Edit, that's new_string. For MultiEdit, it's
+# edits[*].new_string. For Write, it's content.
+new_text=$(printf '%s' "$REVIEWQ_INPUT" | jq -r '
+    (.tool_input.new_string // ""),
+    (.tool_input.content // ""),
+    ((.tool_input.edits // []) | map(.new_string // "") | join("\n"))
+' 2>/dev/null | tr -d '\r')
+[[ -z "$new_text" ]] && exit 0
+
+# Normalize to lowercase for the English patterns. Japanese patterns
+# are matched as-is (case doesn't matter for kanji).
+lower=$(printf '%s' "$new_text" | tr '[:upper:]' '[:lower:]')
+
+patterns_en=(
+    "todo: later"
+    "todo later"
+    "fixme later"
+    "fix in the next iteration"
+    "fix in next iteration"
+    "will fix later"
+    "implement later"
+    "handle this later"
+    "deferred to a future"
+    "come back to this"
+)
+patterns_ja=(
+    "後で対応"
+    "後ほど対応"
+    "次回対応"
+    "次回の対応"
+    "今後改善"
+    "今後の改善"
+    "あとで対応"
+    "後日対応"
+    "将来対応"
+)
+
+hit=""
+for p in "${patterns_en[@]}"; do
+    if printf '%s' "$lower" | grep -Fq -- "$p"; then
+        hit="$p"
+        break
+    fi
+done
+if [[ -z "$hit" ]]; then
+    for p in "${patterns_ja[@]}"; do
+        if printf '%s' "$new_text" | grep -Fq -- "$p"; then
+            hit="$p"
+            break
+        fi
+    done
+fi
+
+[[ -z "$hit" ]] && exit 0
+
+reviewq_block "Procrastination language detected in the new content: '$hit'
+
+reviewq enforces the 'fix it now or track it concretely' rule. Vague
+deferrals like 'TODO: later' accumulate and are never revisited.
+
+Fix (pick one):
+  1. Fix the issue in this turn and remove the comment.
+  2. Open a GitHub issue NOW (gh issue create …) and reference it:
+       // see #<issue-number>
+     Concrete issue references are allowed; vague 'later' comments are
+     not.
+  3. If the deferral is truly the right call, use a precise form like:
+       // blocked by upstream crate X, revisit once vX.Y ships
+     so the trigger is unambiguous.
+
+This gate is documented in .claude/rules/harness-engineering.md."

--- a/.claude/hooks/safety-gate.sh
+++ b/.claude/hooks/safety-gate.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# PreToolUse gate: hard-block destructive shell commands and bypass attempts.
+#
+# Rationale (from harness-engineering articles):
+#   "PreToolUse Hooks: Block risky operations (rm -rf, git push --force)"
+#     — nyosegawa, coding-agent-workflow-2026
+#   "pre-bash-guard: Blocks destructive commands, --no-verify bypasses,
+#    procrastination language" — ignission, Claude Code で実践する
+#
+# Policy:
+#   - Destructive file ops (`rm -rf /`, `rm -rf ~`, wildcard rm)
+#   - Irreversible git ops (`git push --force` on any branch, `git reset --hard`,
+#     `git clean -fdx`, `git branch -D`)
+#   - Hook/verification bypass (`--no-verify`, `--no-gpg-sign`)
+#   - Config file edits routed through Bash (`echo > Cargo.toml`, etc.)
+#   - Exit-2 block with a specific fix message for each class.
+#
+# Non-policy (intentionally allowed):
+#   - `rm -rf <specific-dir>` under the current worktree (needed for cleanup)
+#   - `git push` without --force
+#   - `git reset` without --hard
+#
+# All decisions are logged to hook-log.jsonl for audit.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+[[ "$tool_name" != "Bash" ]] && exit 0
+
+cmd=$(reviewq_jq '.tool_input.command')
+[[ -z "$cmd" ]] && exit 0
+
+# ---- Class 1: indiscriminate rm ----
+# Block `rm -rf /`, `rm -rf ~`, `rm -rf *`, `rm -rf /*`, `rm -rf .`.
+# We use word-boundary regex so things like `rmdir` or `./rm` don't trip.
+if printf '%s' "$cmd" | grep -Eq '(^|[^a-zA-Z_/-])rm[[:space:]]+(-[A-Za-z]*r[A-Za-z]*f|-[A-Za-z]*f[A-Za-z]*r)[[:space:]]+((-{1,2}[A-Za-z-]+[[:space:]]+)*)(/|~|\*|/\*|\.|\.\.)($|[[:space:]])'; then
+    reviewq_block "Indiscriminate 'rm -rf' target detected in: $cmd
+
+This command would delete the root, home, or a wildcard expansion.
+Never run this — even on a dev machine.
+
+Fix:
+  Specify an explicit, scoped directory path (absolute or relative),
+  and verify it first with 'ls -la <path>'.
+  Prefer: git clean -fdx (inside a worktree only)
+  Prefer: rm -rf .worktree/<specific-branch-slug>"
+fi
+
+# ---- Class 2: force-push ----
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]]+.*(--force([[:space:]]|$)|-f([[:space:]]|$))'; then
+    # Allow --force-with-lease (safer) as an escape hatch for intentional
+    # rewrites of a feature branch the user owns.
+    if ! printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]]+.*--force-with-lease'; then
+        reviewq_block "'git push --force' / 'git push -f' detected: $cmd
+
+Force-push rewrites remote history and can destroy other contributors'
+work. reviewq forbids it on any branch by default.
+
+Fix:
+  - If you need to rewrite a feature branch, use --force-with-lease
+    which aborts when the remote has moved:
+      git push --force-with-lease
+  - If you need to update main, rebase and open a PR instead."
+    fi
+fi
+
+# ---- Class 3: hook / verification bypass ----
+if printf '%s' "$cmd" | grep -Eq '(--no-verify|--no-gpg-sign|-c[[:space:]]+commit\.gpgsign=false)'; then
+    reviewq_block "Hook / signing bypass detected in: $cmd
+
+Global ~/.claude/CLAUDE.md explicitly forbids --no-verify, --no-gpg-sign,
+and any other mechanism that skips pre-commit or pre-push hooks.
+
+Fix:
+  Fix whatever is causing the hook to fail. Do not bypass it.
+  If the hook itself is wrong, patch the hook in a chore/ worktree
+  and re-run 'make test-hooks'."
+fi
+
+# ---- Class 4: hard reset / destructive git clean ----
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+reset[[:space:]]+(--hard|.*[[:space:]]--hard)'; then
+    reviewq_block "'git reset --hard' detected in: $cmd
+
+Hard-reset discards uncommitted work and rewrites the index silently.
+This is how ~/.claude/CLAUDE.md 'in-progress work loss' incidents happen.
+
+Fix:
+  - Use 'git stash push -u' to save work-in-progress before resetting.
+  - Use 'git restore <file>' / 'git restore --staged <file>' for targeted
+    reverts.
+  - Use 'git reset --keep <ref>' to reset while aborting on conflicts."
+fi
+
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+clean[[:space:]]+.*(-[A-Za-z]*f[A-Za-z]*x|-[A-Za-z]*x[A-Za-z]*f)'; then
+    reviewq_block "'git clean -fdx' (or -fx) detected in: $cmd
+
+This deletes EVERY untracked file including .gitignored build artifacts,
+.env files, and IDE settings. It has destroyed hours of uncommitted work
+in past incidents.
+
+Fix:
+  Use 'git clean -fd' (without -x) to preserve ignored files, or
+  specify the exact path: 'git clean -fd src/generated/'."
+fi
+
+# ---- Class 5: branch hard-delete ----
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+branch[[:space:]]+.*(-D|--delete[[:space:]]+--force)'; then
+    reviewq_block "'git branch -D' (force-delete) detected in: $cmd
+
+Force-deletes branches with unmerged commits, losing the work.
+
+Fix:
+  - Use 'git branch -d <branch>' (lowercase) to delete only merged
+    branches; it will refuse to delete unmerged work.
+  - If you really need to discard unmerged work, open a PR first and
+    close it, so the ref is preserved in GitHub."
+fi
+
+# ---- Class 6: piping remote scripts to a shell ----
+if printf '%s' "$cmd" | grep -Eq '(curl|wget)[[:space:]]+.*\|[[:space:]]*(sh|bash|zsh)'; then
+    reviewq_block "Piping a remote script directly into a shell detected: $cmd
+
+'curl ... | sh' executes arbitrary code from the network with zero review.
+This is a known supply-chain attack vector.
+
+Fix:
+  Download to a file, inspect it, then run it:
+    curl -fsSLo /tmp/install.sh <url>
+    less /tmp/install.sh
+    bash /tmp/install.sh"
+fi
+
+# ---- Class 7: config file corruption via Bash redirect ----
+# Edits to locked config files must go through Edit/Write (which are gated
+# by the config-protection side of the edit path). Block Bash-level writes
+# here so agents can't smuggle changes past Edit gates via `echo > file`.
+for protected in Cargo.toml Cargo.lock Makefile rustfmt.toml clippy.toml deny.toml rust-toolchain.toml .rustfmt.toml; do
+    if printf '%s' "$cmd" | grep -Eq "(>|>>|tee|sponge)[[:space:]]+(\./)?${protected//./\\.}([[:space:]]|$)"; then
+        reviewq_block "Bash-level write to protected config file '$protected' detected: $cmd
+
+Config files are edited via Write/Edit with explicit user awareness, not
+via shell redirects. This is how silent dependency drift happens.
+
+Fix:
+  Use the Edit tool on $protected so the diff is visible in the
+  conversation and can be reviewed."
+    fi
+done
+
+reviewq_log_event allow "bash command cleared safety checks"
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SessionStart hook: bootstrap every Claude Code session with a concise
+# situational summary, so the agent can pick up work without re-asking
+# the user for context.
+#
+# Rationale (nyosegawa harness-engineering-best-practices-2026):
+#   "Startup Ritual (Automated):
+#      git status
+#      git log --oneline -20
+#      cat PROGRESS.json     # structured state, not Markdown
+#      npm run dev           # smoke test
+#      echo 'Ready for task selection'"
+#
+#   "Git as Memory Bridge: each session closes with a descriptive commit;
+#    next session reads `git log -5` to understand context."
+#
+# We adapt this to reviewq's Rust stack:
+#
+#   - git status --short            (current worktree state)
+#   - git log --oneline -15         (recent history)
+#   - git worktree list             (so the agent knows where it is)
+#   - cat .claude/state/PROGRESS.md if present (free-form resume notes)
+#   - A short hook-enforcement reminder so the agent doesn't re-learn
+#     the rules from scratch every session.
+#
+# All output goes on stdout inside a JSON hookSpecificOutput block so
+# Claude Code merges it into the session context as additional context.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+event=$(reviewq_jq '.hook_event_name')
+[[ "$event" != "SessionStart" ]] && exit 0
+
+cwd=$(reviewq_jq '.cwd')
+[[ -z "$cwd" ]] && cwd=$(reviewq_project_dir)
+[[ ! -d "$cwd" ]] && exit 0
+
+# Walk up to the nearest directory with .git or Cargo.toml so we run
+# git commands from a valid repo root even if the hook fires from a
+# subdirectory.
+probe="$cwd"
+for _ in 1 2 3 4; do
+    if [[ -d "$probe/.git" || -f "$probe/.git" ]]; then
+        break
+    fi
+    parent=$(dirname "$probe")
+    [[ "$parent" == "$probe" ]] && break
+    probe="$parent"
+done
+cwd="$probe"
+
+# --- collect context snippets --------------------------------------------
+status_lines=$( (cd "$cwd" && git status --short --branch) 2>/dev/null | head -20 )
+log_lines=$( (cd "$cwd" && git log --oneline -15) 2>/dev/null )
+worktrees=$( (cd "$cwd" && git worktree list) 2>/dev/null )
+
+progress=""
+progress_path="$cwd/.claude/state/PROGRESS.md"
+if [[ -f "$progress_path" ]]; then
+    progress=$(head -40 "$progress_path")
+fi
+
+# Lines currently in AGENTS.md — noisy warning if it has drifted above
+# the recommended 50-line target from the harness-engineering article.
+agents_md_lines=""
+if [[ -f "$cwd/AGENTS.md" ]]; then
+    n=$(wc -l < "$cwd/AGENTS.md" | tr -d ' ')
+    agents_md_lines="$n"
+fi
+
+# --- assemble the context message ----------------------------------------
+msg=""
+msg+=$'# reviewq session bootstrap\n\n'
+msg+=$'You are a Claude Code agent working on the reviewq Rust CLI/TUI\n'
+msg+=$'project. The session is governed by mechanically enforced hooks\n'
+msg+=$'under .claude/hooks/ — see .claude/hooks/README.md for details.\n\n'
+msg+=$'## Enforcement reminder (non-bypassable)\n\n'
+msg+=$'- Every edit must be inside a .worktree/ directory.\n'
+msg+=$'- AGENTS.md must be Read before the first edit.\n'
+msg+=$'- A Skill() must be invoked before the first *.rs edit.\n'
+msg+=$'- Production *.rs edits are blocked until a test file or\n'
+msg+=$'  tdd-workflow / rust-testing skill has been touched.\n'
+msg+=$'- `git commit` runs fmt-check / clippy -D warnings / cargo test\n'
+msg+=$'  and requires a rust-review-done marker if *.rs is staged.\n'
+msg+=$'- `cargo check` runs on Stop when *.rs files were edited; you\n'
+msg+=$'  cannot end the turn with a broken build.\n'
+msg+=$'- Destructive bash (rm -rf wildcards, force-push, --no-verify,\n'
+msg+=$'  git reset --hard) is blocked by safety-gate.sh.\n\n'
+
+if [[ -n "$status_lines" ]]; then
+    msg+=$'## git status\n\n```\n'
+    msg+="$status_lines"
+    msg+=$'\n```\n\n'
+fi
+
+if [[ -n "$log_lines" ]]; then
+    msg+=$'## Recent commits (git log --oneline -15)\n\n```\n'
+    msg+="$log_lines"
+    msg+=$'\n```\n\n'
+fi
+
+if [[ -n "$worktrees" ]]; then
+    msg+=$'## Active worktrees\n\n```\n'
+    msg+="$worktrees"
+    msg+=$'\n```\n\n'
+fi
+
+if [[ -n "$progress" ]]; then
+    msg+=$'## Resume notes (.claude/state/PROGRESS.md)\n\n```\n'
+    msg+="$progress"
+    msg+=$'\n```\n\n'
+fi
+
+if [[ -n "$agents_md_lines" && "$agents_md_lines" -gt 120 ]]; then
+    msg+=$'## ⚠️ AGENTS.md is getting long\n\n'
+    msg+="Current size: ${agents_md_lines} lines. The harness-engineering\n"
+    msg+=$'best practices recommend ≤50–80 lines using the Pointer Pattern\n'
+    msg+=$'(reference .claude/rules/*.md instead of inlining). Consider a\n'
+    msg+=$'chore/ worktree to trim it.\n\n'
+fi
+
+msg+=$'When in doubt, prefer /harness-status or cat\n'
+msg+=$'.claude/.session/<session_id>/hook-log.jsonl to see what the\n'
+msg+=$'enforcement layer has already decided this session.\n'
+
+reviewq_log_event info "session-start bootstrap emitted"
+
+# Claude Code SessionStart expects additionalContext under the
+# hookSpecificOutput key with hookEventName = "SessionStart".
+jq -Rn --arg msg "$msg" '{
+    hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: $msg
+    }
+}'
+exit 0

--- a/.claude/hooks/skill-routing-gate.sh
+++ b/.claude/hooks/skill-routing-gate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# PreToolUse gate: before editing any Rust source file, require that at
+# least one Skill has been invoked in this session.
+#
+# Rule (`.claude/rules/skills.md`):
+#   "Skills are not optional. Treat the rows below as mandatory defaults."
+#   "Phase 3 — Implement. Trigger: Writing or editing any Rust source file.
+#    Skill(s): rust-patterns, rust-skills:coding-guidelines"
+#
+# This gate is intentionally *coarse*: we only check that *some* Skill was
+# invoked this session, not that the exact skill for the current phase was
+# used. The point is to create friction that forces the router to be
+# consulted at all. Fine-grained per-phase gating would produce too many
+# false positives (e.g. refactors that legitimately don't need rust-async).
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+file_path=$(reviewq_jq '.tool_input.file_path')
+[[ -z "$file_path" ]] && exit 0
+
+# Only enforce for Rust source files. Tests count; doc-only changes don't.
+case "$file_path" in
+    *.rs) ;;
+    *) exit 0 ;;
+esac
+
+# Bootstrap: the hook scripts themselves are shell, not Rust, so they can
+# never trip this gate. Leaving this for defense in depth.
+project_dir=$(reviewq_project_dir)
+case "$file_path" in
+    "$project_dir"/.claude/hooks/*|.claude/hooks/*) exit 0 ;;
+esac
+
+if reviewq_has_mark skill-invoked; then
+    exit 0
+fi
+
+reviewq_block "Editing a Rust source file without first invoking any Skill.
+
+.claude/rules/skills.md makes skill routing mandatory for every task.
+At minimum, before touching Rust code you are expected to have consulted:
+  - rust-patterns              (Phase 3 — Implement)
+  - rust-skills:coding-guidelines
+And, if applicable:
+  - search-first               (Phase 2 — before any new capability)
+  - documentation-lookup       (Phase 2 — crate / API usage)
+  - tdd-workflow + rust-testing (Phase 4 — tests first)
+
+Fix:
+  Invoke the relevant Skill via the Skill tool. Any Skill invocation this
+  session will unblock the gate, so start with the routing phase that
+  matches your task (planning, research, or implement)."

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Stop hook: when the agent signals "done", verify the build actually
+# compiles before letting the turn end. Emits a JSON `{"decision":"block"}`
+# response when the check fails so Claude is forced to keep working.
+#
+# Rationale (from harness-engineering articles):
+#
+#   "Stop Hook: End-of-response hooks... test verification before agent
+#    claims done." — nyosegawa, coding-agent-workflow-2026
+#
+#   "Silent corruption: Agents declare 'done' without verifying end-to-end
+#    behavior." — OpenAI, one of the three harness failure modes
+#
+# Policy:
+#   - If no Rust source files were edited this session (no
+#     rust-files-edited marker), exit 0 (nothing to verify).
+#   - Otherwise run `cargo check --quiet` from the session's cwd.
+#     We use `check`, not `test`, because:
+#       * check catches ~95% of "silent done" lies (compile errors,
+#         missing imports, broken signatures),
+#       * test is slow enough that running it on every turn would make
+#         the agent loop sluggish,
+#       * commit-gate.sh already enforces full `cargo test` before a
+#         commit can land, which is the real quality gate.
+#   - On failure, emit `{"decision":"block","reason":...}` JSON so Claude
+#     sees it and keeps working.
+#   - Also honor a `tests-just-passed` marker: if the commit-gate (or a
+#     /verify slash command) just ran a full suite, skip the check to
+#     avoid double-work.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+# SessionStart / Stop inputs don't carry a tool_name. Guard by hook_event_name.
+event=$(reviewq_jq '.hook_event_name')
+[[ "$event" != "Stop" ]] && exit 0
+
+# Skip if the agent never touched Rust code this session.
+if ! reviewq_has_mark rust-files-edited; then
+    reviewq_log_event allow "Stop: no rust files edited, nothing to check"
+    exit 0
+fi
+
+# Skip if a full verification just ran. The marker is set by commit-gate
+# after a successful build, and naturally expires at session end.
+if reviewq_has_mark tests-just-passed; then
+    reviewq_log_event allow "Stop: tests-just-passed marker present, skip"
+    exit 0
+fi
+
+cwd=$(reviewq_jq '.cwd')
+[[ -z "$cwd" ]] && cwd=$(reviewq_project_dir)
+[[ ! -d "$cwd" ]] && exit 0
+
+# Only run if this directory looks like a Rust crate.
+if [[ ! -f "$cwd/Cargo.toml" ]]; then
+    # Walk up a few levels in case the Stop hook fires from a subdir.
+    found=""
+    probe="$cwd"
+    for _ in 1 2 3 4; do
+        probe=$(dirname "$probe")
+        if [[ -f "$probe/Cargo.toml" ]]; then
+            found="$probe"
+            break
+        fi
+    done
+    if [[ -z "$found" ]]; then
+        reviewq_log_event allow "Stop: no Cargo.toml found near $cwd"
+        exit 0
+    fi
+    cwd="$found"
+fi
+
+log_file="$(reviewq_session_dir)/stop-gate-check.log"
+if (cd "$cwd" && cargo check --quiet --all-targets) >"$log_file" 2>&1; then
+    reviewq_mark tests-just-passed
+    reviewq_log_event allow "Stop: cargo check passed"
+    exit 0
+fi
+
+tail_output=$(tail -40 "$log_file")
+reason=$(printf 'Stop blocked: `cargo check` does not compile. You cannot claim "done" while the build is broken.\n\nLast 40 lines:\n%s\n\nFix the compile errors (and their root causes — do not #[allow] them) before ending the turn. The commit-gate will additionally enforce full clippy + test on git commit.' "$tail_output")
+
+reviewq_log_event block "Stop: cargo check failed"
+
+# Emit Stop-hook JSON on stdout so Claude treats this as a block-with-
+# guidance rather than a fatal error.
+jq -n --arg reason "$reason" '{
+    decision: "block",
+    reason: $reason
+}'
+exit 0

--- a/.claude/hooks/tdd-gate.sh
+++ b/.claude/hooks/tdd-gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# PreToolUse gate: enforce "tests first" before any production Rust file
+# edit in a session.
+#
+# Rationale:
+#   AGENTS.md → Plan-First Rule + `.claude/rules/skills.md` Phase 4:
+#     "TDD Approach: Write tests first (RED), implement to pass tests
+#      (GREEN), refactor (IMPROVE)."
+#   nyosegawa coding-agent-workflow-2026: "tdd-guard Hook: Prevents code
+#     generation without passing tests."
+#   ignission hunting-to-farming: "rules don't block; hooks do."
+#
+# Policy:
+#   Before an agent may edit any *production* Rust file in this session,
+#   at least ONE of these must hold:
+#     (a) A test file has been edited or created in this session
+#         (marker: tests-edited)
+#     (b) The `tdd-workflow` or `rust-testing` skill has been invoked
+#         (marker: tdd-tests-written — set by mark-post-tool.sh)
+#     (c) The edit itself targets a test file (it's a test, not prod code)
+#     (d) The edit is under .claude/hooks/ (bootstrap exemption)
+#
+# Rationale for (a): manually editing a test file counts as "tests first"
+# because the agent has at minimum *touched* the test surface before
+# touching production. This is looser than a strict git-history check but
+# much harder to cheat than marker-only.
+#
+# We deliberately do NOT enforce that the test failed before implementation,
+# because detecting Red→Green mechanically requires running `cargo test`
+# between every edit, which is too slow for the PreToolUse layer.
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+file_path=$(reviewq_jq '.tool_input.file_path')
+[[ -z "$file_path" ]] && exit 0
+
+# Non-Rust edits never trip this gate.
+case "$file_path" in
+    *.rs) ;;
+    *) exit 0 ;;
+esac
+
+project_dir=$(reviewq_project_dir)
+
+# Bootstrap: hook scripts and session state can always be edited.
+case "$file_path" in
+    "$project_dir"/.claude/*) exit 0 ;;
+    .claude/*) exit 0 ;;
+esac
+
+# (c) The edit itself IS a test — allow.
+case "$file_path" in
+    *_test.rs|*/tests/*|*/test_*.rs) exit 0 ;;
+esac
+
+# For *.rs files that aren't explicitly under tests/, peek inside to see
+# if this file is an in-file test module. If the existing file contains
+# #[cfg(test)] or #[test], treat the edit as a test edit.
+if [[ -f "$file_path" ]] && grep -qE '^\s*#\[(cfg\(test\)|test)' "$file_path" 2>/dev/null; then
+    exit 0
+fi
+
+# (a) & (b): check markers.
+if reviewq_has_mark tests-edited || reviewq_has_mark tdd-tests-written; then
+    exit 0
+fi
+
+reviewq_block "TDD gate: editing production Rust file without any prior test.
+
+'$file_path' is a production Rust source file, but this session has not
+yet:
+  (a) edited or created any test file, or
+  (b) invoked the tdd-workflow / rust-testing skill, or
+  (c) edited a file that already contains #[cfg(test)] / #[test].
+
+Test-Driven Development is mandatory per AGENTS.md and
+.claude/rules/skills.md Phase 4:
+  1. Red    — write a failing test that expresses the requirement.
+  2. Green  — implement the minimum code needed to make the test pass.
+  3. Refactor — keep tests green, clean logic.
+
+Fix (pick one):
+  - Invoke the tdd-workflow or rust-testing skill to plan the test:
+      Skill(tdd-workflow)     or     Skill(rust-testing)
+  - Or start by creating/editing the relevant test file first. Any
+    *_test.rs, tests/**/*.rs, or *.rs file containing #[cfg(test)]
+    qualifies and will set the marker automatically.
+
+This gate exists because soft 'please write tests first' guidance has
+historically been ignored. The only way past it is to actually write a
+test or explicitly plan one."

--- a/.claude/hooks/tests/run-tests.sh
+++ b/.claude/hooks/tests/run-tests.sh
@@ -1,0 +1,623 @@
+#!/usr/bin/env bash
+# Self-test harness for reviewq Claude Code hooks.
+#
+# Each case feeds a synthetic JSON payload into one of the hook scripts,
+# captures its exit code, and compares against an expectation. We do not
+# need a live Claude Code session; the hook I/O contract is stdin-JSON
+# and exit-code, which is trivial to fake.
+#
+# Run:
+#   .claude/hooks/tests/run-tests.sh
+# or:
+#   make test-hooks
+#
+# Exits 0 if all assertions pass, non-zero otherwise.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOKS="$(cd "$HERE/.." && pwd)"
+REPO="$(cd "$HOOKS/../.." && pwd)"
+
+export CLAUDE_PROJECT_DIR="$REPO"
+# Isolated session dir — we create a fresh session_id per test case so
+# tests never see stale markers from each other or from a real session.
+FAIL=0
+PASS=0
+
+# Each test runs in a scratch session dir that we wipe after use.
+scratch_session() {
+    printf 'test-%s-%s' "$(date +%s)" "$RANDOM"
+}
+
+expect() {
+    local name="$1" expected="$2" actual="$3" stderr="$4"
+    if [[ "$actual" == "$expected" ]]; then
+        printf '  \e[32mPASS\e[0m %s (exit=%s)\n' "$name" "$actual"
+        PASS=$((PASS + 1))
+    else
+        printf '  \e[31mFAIL\e[0m %s (exit=%s, expected=%s)\n' "$name" "$actual" "$expected"
+        if [[ -n "$stderr" ]]; then
+            printf '        stderr: %s\n' "$(printf '%s' "$stderr" | head -3 | tr '\n' ' ')"
+        fi
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Run a hook with a JSON input, return exit code and stderr.
+run_hook() {
+    local hook="$1" input="$2"
+    local err
+    err=$(printf '%s' "$input" | "$HOOKS/$hook" 2>&1 >/dev/null)
+    local rc=$?
+    printf '%s\n%s' "$rc" "$err"
+}
+
+runcase() {
+    local name="$1" hook="$2" expected_exit="$3" input="$4"
+    local out rc err
+    out=$(printf '%s' "$input" | "$HOOKS/$hook" 2>&1 >/dev/null)
+    rc=$?
+    expect "$name" "$expected_exit" "$rc" "$out"
+}
+
+# Helper: mark a marker for the given session_id.
+mark_for_session() {
+    local sid="$1" marker="$2"
+    local dir="$REPO/.claude/.session/$sid"
+    mkdir -p "$dir"
+    touch "$dir/$marker"
+}
+
+cleanup_session() {
+    local sid="$1"
+    rm -rf "$REPO/.claude/.session/$sid"
+}
+
+echo "== worktree-gate.sh =="
+
+SID=$(scratch_session); mark_for_session "$SID" agents-md-read; mark_for_session "$SID" skill-invoked
+runcase "allow: edit inside worktree" worktree-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: edit in main tree src/" worktree-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/src/main.rs"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: edit .claude/hooks/ in main tree (bootstrap hatch)" worktree-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.claude/hooks/worktree-gate.sh"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: edit outside repo entirely" worktree-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"/tmp/scratch.txt"},
+  "cwd":"/tmp"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: non-edit tool is a no-op" worktree-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"ls"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+echo "== agents-md-gate.sh =="
+
+SID=$(scratch_session)
+runcase "block: edit before AGENTS.md read" agents-md-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" agents-md-read
+runcase "allow: edit after AGENTS.md read" agents-md-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: edit under .claude/hooks/ without AGENTS.md read (bootstrap)" agents-md-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.claude/hooks/foo.sh"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+echo "== skill-routing-gate.sh =="
+
+SID=$(scratch_session)
+runcase "block: .rs edit before any Skill() invocation" skill-routing-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" skill-invoked
+runcase "allow: .rs edit after Skill() marker" skill-routing-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: non-rust edit is a no-op" skill-routing-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/README.md"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+echo "== commit-gate.sh (command detection only — does not actually run cargo) =="
+
+SID=$(scratch_session)
+runcase "allow: bash that is not a commit" commit-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"ls -la"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: 'git commit --help' is not a real commit" commit-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git commit --help"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: 'git commit-tree' is not a real commit" commit-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git commit-tree abc123 -m foo"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+# Use a scratch dir that is deliberately NOT inside any `.worktree/`
+# directory so the gate's worktree check fires. We never actually run
+# cargo in this test — the worktree check blocks first.
+FAKE_MAIN=$(mktemp -d "${TMPDIR:-/tmp}/reviewq-gate-test-XXXXXX")
+runcase "block: 'git commit' from outside a worktree" commit-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git commit -m test"},
+  "cwd":"'"$FAKE_MAIN"'"
+}'
+rm -rf "$FAKE_MAIN"
+cleanup_session "$SID"
+
+echo "== mark-post-tool.sh =="
+
+SID=$(scratch_session)
+# Feeding a Read of AGENTS.md should touch the marker.
+printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Read",
+  "tool_input":{"file_path":"'"$REPO"'/AGENTS.md"}
+}' | "$HOOKS/mark-post-tool.sh" >/dev/null 2>&1
+if [[ -f "$REPO/.claude/.session/$SID/agents-md-read" ]]; then
+    printf '  \e[32mPASS\e[0m sets agents-md-read marker on Read(AGENTS.md)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m marker not set\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Skill",
+  "tool_input":{"skill":"rust-patterns"}
+}' | "$HOOKS/mark-post-tool.sh" >/dev/null 2>&1
+if [[ -f "$REPO/.claude/.session/$SID/skill-invoked" ]]; then
+    printf '  \e[32mPASS\e[0m sets skill-invoked on Skill()\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m skill-invoked marker not set\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Agent",
+  "tool_input":{"subagent_type":"rust-reviewer","description":"review"}
+}' | "$HOOKS/mark-post-tool.sh" >/dev/null 2>&1
+if [[ -f "$REPO/.claude/.session/$SID/rust-review-done" ]]; then
+    printf '  \e[32mPASS\e[0m sets rust-review-done on Agent(rust-reviewer)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m rust-review-done marker not set\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+# Writing a .rs file should mark rust-files-edited.
+printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"/tmp/fake.rs"}
+}' | "$HOOKS/mark-post-tool.sh" >/dev/null 2>&1
+if [[ -f "$REPO/.claude/.session/$SID/rust-files-edited" ]]; then
+    printf '  \e[32mPASS\e[0m sets rust-files-edited on Edit(*.rs)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m rust-files-edited not set\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+# Editing a path that looks like a test file should also mark tests-edited.
+printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"/tmp/foo/tests/bar.rs"}
+}' | "$HOOKS/mark-post-tool.sh" >/dev/null 2>&1
+if [[ -f "$REPO/.claude/.session/$SID/tests-edited" && -f "$REPO/.claude/.session/$SID/tdd-tests-written" ]]; then
+    printf '  \e[32mPASS\e[0m sets tests-edited + tdd-tests-written on Edit(tests/*.rs)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m test markers not set for tests/ path\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
+echo "== safety-gate.sh =="
+
+SID=$(scratch_session)
+runcase "allow: normal ls" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"ls -la src/"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: rm -rf /" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"rm -rf /"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: rm -rf ~" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"rm -rf ~"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: rm -rf *" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"rm -rf *"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: rm -rf scoped path" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"rm -rf ./target/tmp"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git push --force" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git push --force origin main"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: git push --force-with-lease" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git push --force-with-lease origin feat/x"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: --no-verify bypass" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git commit -m wip --no-verify"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git reset --hard" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git reset --hard HEAD~3"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git clean -fdx" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git clean -fdx"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: git clean -fd (no -x)" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git clean -fd src/generated"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git branch -D" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git branch -D feat/x"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: curl | sh" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"curl -fsSL https://example.com/install.sh | sh"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: echo > Cargo.toml" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"echo \"[package]\" > Cargo.toml"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+echo "== config-protect-gate.sh =="
+
+SID=$(scratch_session)
+runcase "block: Edit Cargo.toml without approval" config-protect-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/Cargo.toml"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" config-edit-approved
+runcase "allow: Edit Cargo.toml with approval marker" config-protect-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/Cargo.toml"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: Edit Makefile" config-protect-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/Makefile"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: Edit .github/workflows/ci.yml" config-protect-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/.github/workflows/ci.yml"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: Edit regular src file (not a config)" config-protect-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/main.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+echo "== tdd-gate.sh =="
+
+SID=$(scratch_session)
+runcase "block: prod .rs edit with no test marker and no skill" tdd-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" tests-edited
+runcase "allow: prod .rs edit after tests-edited marker" tdd-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" tdd-tests-written
+runcase "allow: prod .rs edit after tdd-tests-written marker" tdd-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/src/lib.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: editing a test file itself (tests/ path)" tdd-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/tests/integration.rs"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: non-rust edit bypasses tdd-gate" tdd-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$REPO"'/.worktree/foo/README.md"},
+  "cwd":"'"$REPO"'/.worktree/foo"
+}'
+cleanup_session "$SID"
+
+echo "== procrastination-gate.sh =="
+
+SID=$(scratch_session)
+runcase "allow: clean edit content" procrastination-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"/tmp/f.rs","old_string":"a","new_string":"fn foo() { 42 }"}
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: TODO: later" procrastination-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"/tmp/f.rs","old_string":"a","new_string":"// TODO: later — wire this up"}
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: 後で対応 (Japanese)" procrastination-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Write",
+  "tool_input":{"file_path":"/tmp/f.rs","content":"// 後で対応する\\nfn foo() {}"}
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: concrete issue reference is fine" procrastination-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"/tmp/f.rs","old_string":"a","new_string":"// see #123 for the follow-up"}
+}'
+cleanup_session "$SID"
+
+echo "== stop-gate.sh =="
+
+# stop-gate does nothing if no .rs files were edited this session.
+SID=$(scratch_session)
+runcase "allow: Stop with no rust-files-edited marker" stop-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "hook_event_name":"Stop",
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" rust-files-edited; mark_for_session "$SID" tests-just-passed
+runcase "allow: Stop with tests-just-passed marker" stop-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "hook_event_name":"Stop",
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+echo "== session-start.sh =="
+
+# session-start emits JSON on stdout; just verify exit code and that the
+# JSON parses cleanly.
+SID=$(scratch_session)
+json_out=$(printf '%s' '{
+  "session_id":"'"$SID"'",
+  "hook_event_name":"SessionStart",
+  "cwd":"'"$REPO"'"
+}' | "$HOOKS/session-start.sh" 2>/dev/null)
+if printf '%s' "$json_out" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+    printf '  \e[32mPASS\e[0m emits valid hookSpecificOutput JSON\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m session-start did not emit valid JSON\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
+echo "== post-edit-rust.sh =="
+
+# post-edit-rust should mark rust-files-edited on Rust edits.
+SID=$(scratch_session)
+scratch_rs=$(mktemp "${TMPDIR:-/tmp}/post-edit-XXXXXX.rs")
+printf 'fn main() { println!("hi"); }\n' > "$scratch_rs"
+printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Edit",
+  "tool_input":{"file_path":"'"$scratch_rs"'"}
+}' | "$HOOKS/post-edit-rust.sh" >/dev/null 2>&1
+if [[ -f "$REPO/.claude/.session/$SID/rust-files-edited" ]]; then
+    printf '  \e[32mPASS\e[0m post-edit-rust marks rust-files-edited\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m post-edit-rust did not set marker\n'
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$scratch_rs"
+cleanup_session "$SID"
+
+echo
+echo "== Summary =="
+printf "  passed: %d\n  failed: %d\n" "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/.claude/hooks/worktree-gate.sh
+++ b/.claude/hooks/worktree-gate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# PreToolUse gate: block edits inside the reviewq main worktree.
+#
+# Rule (AGENTS.md → Git Workflow):
+#   "Every development task — including single-file edits, typo fixes, and
+#   docs-only changes — MUST start by creating a dedicated git worktree
+#   under .worktree/<branch-name>/. Editing files in the main worktree is
+#   not allowed, even when the change looks trivial."
+#
+# Policy:
+#   - Paths outside the reviewq repo           → allow
+#   - Paths under $reviewq_root/.worktree/**   → allow
+#   - Paths under $reviewq_root/.claude/hooks/** → allow (self-install path;
+#       the hooks have to be editable or they cannot be bootstrapped)
+#   - Any other path inside $reviewq_root      → BLOCK
+
+. "$(dirname "$0")/lib/common.sh"
+reviewq_require_jq
+reviewq_read_input
+
+tool_name=$(reviewq_jq '.tool_name')
+case "$tool_name" in
+    Write|Edit|MultiEdit|NotebookEdit) ;;
+    *) exit 0 ;;
+esac
+
+file_path=$(reviewq_jq '.tool_input.file_path')
+[[ -z "$file_path" ]] && exit 0
+
+project_dir=$(reviewq_project_dir)
+[[ -z "$project_dir" ]] && exit 0
+
+# Normalize to absolute path. If the input is relative, join with project_dir.
+case "$file_path" in
+    /*) abs_path="$file_path" ;;
+    *)  abs_path="$project_dir/$file_path" ;;
+esac
+
+# Outside the reviewq repo → allow.
+case "$abs_path" in
+    "$project_dir"/*) ;;
+    *) exit 0 ;;
+esac
+
+# Inside a worktree → allow.
+case "$abs_path" in
+    "$project_dir"/.worktree/*) exit 0 ;;
+esac
+
+# Bootstrap escape hatch: allow editing the hooks themselves from main.
+# Without this, there is no way to install or fix the hooks, because editing
+# them would block on the very gate they implement.
+case "$abs_path" in
+    "$project_dir"/.claude/hooks/*) exit 0 ;;
+    "$project_dir"/.claude/.session/*) exit 0 ;;
+esac
+
+reviewq_block "Edit of '$file_path' is inside the main reviewq worktree.
+
+AGENTS.md requires every task to run inside a git worktree under
+.worktree/<branch>/, with no size or scope exemption.
+
+Fix:
+  git worktree add -b <type>/<slug> .worktree/<type>-<slug>
+  cd .worktree/<type>-<slug>
+
+Then retry the edit from the worktree. If you already have uncommitted
+changes on main, stash first:
+  git stash push -u
+  git worktree add -b <type>/<slug> .worktree/<type>-<slug>
+  git -C .worktree/<type>-<slug> stash pop"

--- a/.claude/rules/harness-engineering.md
+++ b/.claude/rules/harness-engineering.md
@@ -1,0 +1,99 @@
+# Harness Engineering for reviewq
+
+> "The human's job shifts from 'writing correct code' to 'designing
+> environments where agents reliably produce correct code.'"
+> — Mitchell Hashimoto
+
+This document explains *why* every hook in `.claude/hooks/` exists and
+how they compose into an autonomous-but-safe workflow for the reviewq
+Rust CLI/TUI. It is the project's theoretical spine. The mechanical
+enforcement lives in `.claude/hooks/`; the operational how-to lives in
+`AGENTS.md` and `.claude/rules/skills.md`.
+
+## The three failure modes (OpenAI)
+
+Every gate below targets at least one of these:
+
+1. **Drift** — the agent copies a nearby anti-pattern instead of the
+   ideal pattern. Counter: `skill-routing-gate`, `rust-review` marker.
+2. **Scope creep** — the agent sacrifices non-target goals to get a
+   narrow objective done. Counter: `worktree-gate`, plan-first rule,
+   `config-protect-gate`.
+3. **Silent corruption** — the agent declares "done" without verifying
+   behavior. Counter: `stop-gate`, `commit-gate`, `post-edit-rust`.
+
+## Feedback loop speed hierarchy
+
+From nyosegawa's harness-engineering best-practices article:
+
+```
+  milliseconds   — PostToolUse formatter (post-edit-rust.sh → rustfmt --check)
+  seconds        — PreToolUse gates (worktree / agents-md / skill / tdd)
+  seconds        — Stop hook (cargo check --all-targets)
+  tens of sec    — commit-gate (cargo fmt --check + clippy + test)
+  minutes        — CI (full test matrix, not yet wired)
+  hours+         — human review (PR approval, only on risky changes)
+```
+
+**Rule**: whenever a check exists only at CI, ask whether it can migrate
+into commit-gate. Whenever it exists at commit-gate, ask whether it can
+migrate into the Stop or PostToolUse layer. Faster feedback = smaller
+defect windows = less wasted agent work.
+
+## Hook index
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `session-start.sh`        | SessionStart | Emit git status / log / worktree list / PROGRESS.md as context so the agent resumes with state. |
+| `worktree-gate.sh`        | PreToolUse Edit/Write | Block edits outside `.worktree/` per AGENTS.md. |
+| `agents-md-gate.sh`       | PreToolUse Edit/Write | Require AGENTS.md was Read this session. |
+| `config-protect-gate.sh`  | PreToolUse Edit/Write | Block edits to Cargo.toml / Makefile / CI / linter config unless `/config-edit` unlocks. |
+| `skill-routing-gate.sh`   | PreToolUse Edit/Write on `*.rs` | Require at least one Skill() call before editing Rust. |
+| `tdd-gate.sh`             | PreToolUse Edit/Write on `*.rs` | Require a test file or tdd skill before production Rust edits. |
+| `procrastination-gate.sh` | PreToolUse Edit/Write | Block "TODO: later" / "後で対応" patterns in new content. |
+| `safety-gate.sh`          | PreToolUse Bash | Block `rm -rf /`, `git push --force`, `git reset --hard`, `--no-verify`, `curl \| sh`, Bash-level config writes. |
+| `commit-gate.sh`          | PreToolUse Bash (`git commit`) | Run fmt-check / clippy / test + require `rust-review-done` + `e2e-done` markers where relevant. |
+| `post-edit-rust.sh`       | PostToolUse Edit/Write | Run `rustfmt --check` on edited Rust files and inject the diff back as `additionalContext`. |
+| `mark-post-tool.sh`       | PostToolUse Read/Skill/Agent/Write/Edit | Update session markers so downstream gates can check state. |
+| `stop-gate.sh`            | Stop | Run `cargo check --all-targets` if Rust was edited; emit `{decision: "block"}` on failure. |
+
+## Marker vocabulary
+
+Markers live under `.claude/.session/<session_id>/`. They are just empty
+files; their presence encodes workflow state.
+
+| Marker | Set by | Read by | Meaning |
+|--------|--------|---------|---------|
+| `agents-md-read`        | Read(AGENTS.md) | agents-md-gate | AGENTS.md consumed this session |
+| `skill-invoked`         | any Skill() | skill-routing-gate | some routing skill was used |
+| `skill:<name>`          | Skill(name) | *(future gates)* | per-skill marker |
+| `rust-files-edited`     | Edit/Write on `*.rs` | stop-gate, harness-status | Rust was touched |
+| `tests-edited`          | Edit/Write on test files | *(audit)* | a test file was edited |
+| `tdd-tests-written`     | rust-testing/tdd skill OR test file edit | tdd-gate | TDD prerequisite satisfied |
+| `rust-review-done`      | Agent(rust-reviewer) / Skill(rust-review) | commit-gate | review completed |
+| `e2e-done`              | Skill(reviewq-e2e) | commit-gate | TUI e2e completed |
+| `tests-just-passed`     | commit-gate after `cargo test` | stop-gate | skip redundant check |
+| `config-edit-approved`  | /config-edit slash command | config-protect-gate | config edits unlocked |
+
+## Never bypass
+
+Per global `~/.claude/CLAUDE.md`:
+
+- `--no-verify`, `--no-gpg-sign`, `-c commit.gpgsign=false` are forbidden.
+- Any environment variable or CLI flag that disables hooks is forbidden.
+- If a hook is wrong, patch it in a `chore/hook-*` worktree, add a
+  regression test in `.claude/hooks/tests/run-tests.sh`, and re-run
+  `make test-hooks`. Do not bypass.
+- `.claude/hooks/**` and `.claude/.session/**` are the only paths where
+  edits on the main tree are allowed, and only to bootstrap the hooks
+  themselves.
+
+## Observability
+
+Every block decision is appended to
+`.claude/.session/<session_id>/hook-log.jsonl` as a single JSON line
+`{ts, hook, tool, decision, reason}`. Use `/harness-status` to inspect
+the current session at any time. The log is session-scoped and does
+not persist across sessions — for long-lived debugging, copy relevant
+lines into `.claude/state/PROGRESS.md`.
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,93 @@
     "allow": [
       "Bash(agent-browser *)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/agents-md-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/config-protect-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/skill-routing-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/tdd-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/procrastination-gate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/safety-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/commit-gate.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read|Skill|Agent|Task|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/mark-post-tool.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-rust.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stop-gate.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /output
 .worktree/*
 .worktrees/*
+
+# Session-scoped state written by .claude/hooks/ — namespaced per session_id
+# and never needed across sessions.
+.claude/.session/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,32 @@ make all          # format + lint + test
 make fmt          # cargo fmt
 make lint         # cargo clippy -- -D warnings
 make test         # cargo test
+
+# Workflow-enforcement hook self-tests (see .claude/hooks/README.md)
+make test-hooks
 ```
+
+## Workflow Enforcement Hooks
+
+`.claude/hooks/` contains **mechanically enforced** gates wired into
+`.claude/settings.json` that block tool calls when the workflow below
+is not being followed. They exist because soft guidance in
+`CLAUDE.md` and `.claude/rules/` was historically skipped.
+
+| Gate | Blocks when … |
+|------|----------------|
+| `worktree-gate.sh` | Editing any file in the main reviewq worktree outside `.worktree/**` (only `.claude/hooks/**` is allowed, for bootstrap). |
+| `agents-md-gate.sh` | Any edit before this `AGENTS.md` has been `Read` in the current session. |
+| `skill-routing-gate.sh` | Editing any `*.rs` file before any `Skill()` call has been made this session. |
+| `commit-gate.sh` | `git commit` when `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` fails, when the commit is from outside a `.worktree/`, when `*.rs` files are staged without a `rust-review-done` marker, or when `src/tui/**` files are staged without an `e2e-done` marker. |
+
+Markers are set automatically by `mark-post-tool.sh` (a PostToolUse
+dispatcher) when the matching tool runs. They are session-scoped under
+`.claude/.session/<session_id>/` and discarded at session end.
+
+**Never bypass these hooks.** The global `~/.claude/CLAUDE.md` forbids
+`--no-verify` and any hook disable. If a gate is wrong, patch the
+hook in a `chore/` worktree and re-run `make test-hooks`.
 
 ## Git Workflow (MUST FOLLOW)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: all check fmt lint test build clean
+.PHONY: all check fmt lint test build clean test-hooks
 
 # Default target: run all
-all: fmt lint test
+all: fmt lint test test-hooks
 
 # Format
 fmt:
@@ -35,5 +35,9 @@ check:
 clean:
 	cargo clean
 
-# For CI: fmt-check + lint + test
-ci: fmt-check lint test
+# Workflow enforcement hook self-tests. See .claude/hooks/README.md.
+test-hooks:
+	@bash .claude/hooks/tests/run-tests.sh
+
+# For CI: fmt-check + lint + test + hooks
+ci: fmt-check lint test test-hooks


### PR DESCRIPTION
## Summary

Adds a mechanically enforced **harness layer** under `.claude/hooks/` that blocks workflow-violating tool calls instead of relying on soft rules Claude has historically ignored. Based on the "Harness Engineering" best practices published by OpenAI / Anthropic / nyosegawa / ignission / et al. in early 2026.

Design principle: **rules don't block; hooks do.** Every gate is a bash script that reads the Claude Code tool-call JSON on stdin, decides allow vs block via exit code (`0` / `2`), and logs the decision to a per-session JSONL for audit. Soft-fail EXIT trap ensures a buggy hook never stalls legitimate work — only explicit `reviewq_block` calls exit 2.

## What it blocks

### PreToolUse Edit/Write/MultiEdit
- **worktree-gate.sh** — edits outside `.worktree/**` (per AGENTS.md)
- **agents-md-gate.sh** — any edit before `AGENTS.md` was `Read` this session
- **config-protect-gate.sh** — edits to `Cargo.toml` / `Makefile` / `clippy.toml` / `rustfmt.toml` / `deny.toml` / `rust-toolchain.toml` / `.gitignore` / `.github/workflows/**` unless `/config-edit` unlocked the session
- **skill-routing-gate.sh** — `*.rs` edits before any `Skill()` call
- **tdd-gate.sh** — production `*.rs` edits before a test file or `tdd-workflow` / `rust-testing` skill
- **procrastination-gate.sh** — `TODO: later`, `後で対応`, `次回対応` and other deferral-language patterns in new content

### PreToolUse Bash
- **safety-gate.sh** — `rm -rf` wildcards, `git push --force` (allows `--force-with-lease`), `--no-verify`, `git reset --hard`, `git clean -fdx`, `git branch -D`, `curl | sh`, Bash redirects to protected config files
- **commit-gate.sh** — on `git commit`: runs `cargo fmt --check` + `clippy -D warnings` + `cargo test`, requires worktree cwd, requires `rust-review-done` marker when `*.rs` is staged, `e2e-done` marker when `src/tui/**` is staged

### PostToolUse feedback loops
- **mark-post-tool.sh** — sets session markers (`agents-md-read`, `skill-invoked`, `rust-files-edited`, `tests-edited`, `tdd-tests-written`, `rust-review-done`, `e2e-done`) so downstream gates can reason about state
- **post-edit-rust.sh** — runs `rustfmt --check` on every edited Rust file and injects the diff as `hookSpecificOutput.additionalContext` so the agent self-corrects on the next turn (millisecond feedback layer)

### Stop
- **stop-gate.sh** — when `*.rs` files were edited this session, runs `cargo check --all-targets` before allowing the turn to end; emits `{"decision":"block","reason":"..."}` JSON if the build is broken, preventing "silent done" lies

### SessionStart
- **session-start.sh** — emits `git status --short --branch` + `git log --oneline -15` + `git worktree list` + `.claude/state/PROGRESS.md` as `additionalContext` so agents resume with state

## Bootstrap escape hatch

Only `.claude/hooks/**` and `.claude/.session/**` are editable from the main tree without the usual gates, so the hooks can be patched without being blocked by themselves. No other bypass exists. Global `~/.claude/CLAUDE.md` still forbids `--no-verify` / hook disables.

## Observability

Every block decision is appended to `.claude/.session/<session_id>/hook-log.jsonl` with `{ts, hook, tool, decision, reason}`. Two new slash commands:

- `/config-edit` — unlock protected config edits for the current session
- `/harness-status` — print markers, recent hook log, and a commit-readiness checklist

## Session state

`.claude/.session/` is gitignored and namespaced per `session_id`, so markers are discarded automatically at session end without explicit cleanup.

## Tests

New `make test-hooks` target runs `.claude/hooks/tests/run-tests.sh` which feeds synthetic JSON payloads to each hook and asserts exit codes + side effects. **52 cases** covering allow/block for every gate plus marker mutations. Wired into `make all` and `make ci`.

```
== Summary ==
  passed: 52
  failed: 0
```

Existing `cargo test` suite: **215 passed, 0 failed**.

## Test plan

- [x] `make test-hooks` — 52/52 pass
- [x] `make all` (fmt + lint + test + test-hooks) green
- [x] `cargo test` — 215 pass
- [x] `bash -n` syntax check on every hook + lib + test runner
- [ ] Live session: verify `SessionStart` hook fires and injects context (synthetic JSON test only — the Stop / SessionStart JSON schema cannot be fully asserted without a running Claude Code)
- [ ] Live session: verify `post-edit-rust.sh` injects rustfmt diffs via `hookSpecificOutput.additionalContext`
- [ ] Live session: verify `safety-gate.sh` blocks a real `rm -rf /` attempt
- [ ] Live session: verify `commit-gate.sh` blocks a commit when clippy warnings exist

## Files changed

```
.claude/commands/config-edit.md           (new)
.claude/commands/harness-status.md        (new)
.claude/hooks/README.md                   (new)
.claude/hooks/agents-md-gate.sh           (new)
.claude/hooks/commit-gate.sh              (new)
.claude/hooks/config-protect-gate.sh      (new)
.claude/hooks/lib/common.sh               (new)
.claude/hooks/mark-post-tool.sh           (new)
.claude/hooks/post-edit-rust.sh           (new)
.claude/hooks/procrastination-gate.sh     (new)
.claude/hooks/safety-gate.sh              (new)
.claude/hooks/session-start.sh            (new)
.claude/hooks/skill-routing-gate.sh       (new)
.claude/hooks/stop-gate.sh                (new)
.claude/hooks/tdd-gate.sh                 (new)
.claude/hooks/tests/run-tests.sh          (new)
.claude/hooks/worktree-gate.sh            (new)
.claude/rules/harness-engineering.md      (new)
.claude/settings.json                     (wire hooks)
.gitignore                                (ignore .claude/.session/)
AGENTS.md                                 (document enforcement layer)
Makefile                                  (test-hooks target, wire into all/ci)
```

22 files changed, 2491 insertions(+), 4 deletions(-).