### PR TITLE
chore: harness iter2 — squash-merge detect, cd-prefix parse, AGENTS.md trim

### DIFF
--- a/.claude/commands/confirm-branch-delete.md
+++ b/.claude/commands/confirm-branch-delete.md
@@ -1,0 +1,53 @@
+---
+description: Opt-in approval for force-deleting a branch with unmerged commits
+argument-hint: "<branch-name>"
+---
+
+# /confirm-branch-delete — force-delete a branch with unmerged work
+
+`.claude/hooks/safety-gate.sh` blocks `git branch -D <name>` by default.
+Two automatic escape hatches exist:
+
+1. If the target branch was regular-merged, `git branch -d` (lowercase)
+   handles it; no opt-in needed.
+2. If the target branch was **squash-merged** via a GitHub PR, the gate
+   auto-unblocks when `gh pr list --head <name> --state merged` reports
+   a `MERGED` PR.
+
+This command is the **third escape hatch**: an explicit human opt-in
+for the case where the branch is genuinely unmerged and you want to
+discard the work anyway (e.g. an abandoned experiment that never landed
+in any form).
+
+## Arguments
+
+- `$1` — the branch name to approve for deletion. Slashes are allowed;
+  they are translated to `__` in the marker filename.
+
+## What Claude does on this command
+
+```bash
+name="$1"
+if [[ -z "$name" ]]; then
+    echo "usage: /confirm-branch-delete <branch-name>"
+    exit 1
+fi
+
+ROOT="$CLAUDE_PROJECT_DIR/.claude/.session"
+SID=$(ls -t "$ROOT" 2>/dev/null | head -1)
+if [[ -z "$SID" ]]; then
+    echo "No active session dir. Run any tool first, then retry."
+    exit 1
+fi
+
+safe_name="${name//\//__}"
+mkdir -p "$ROOT/$SID"
+touch "$ROOT/$SID/branch-delete-approved:$safe_name"
+
+echo "✅ Branch-delete approved for '$name' in session $SID."
+echo "   The marker will be discarded automatically at session end."
+echo "   You can now run: git branch -D $name"
+```
+
+After the marker is set, retry the blocked `git branch -D` and
+`safety-gate.sh` will allow it exactly once, for exactly this branch.

--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -58,10 +58,39 @@ if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]])(echo|printf|grep|rg|awk|sed)([
     fi
 fi
 
-# cwd from the hook input is where the Bash tool will execute the command,
-# which is where we need to run `cargo`.
+# cwd from the hook input is the persistent session cwd, which is almost
+# always the main worktree (where Claude Code was started). When the
+# agent composes a command like `cd .worktree/<branch> && git commit ...`
+# the `cd` changes the effective cwd for the command, but the hook JSON
+# still reports the session cwd. Parse a leading `cd <path>` off the
+# command so we can check the gate against the ACTUAL directory the
+# commit will run in. Supports both `cd X && ...` and `cd X; ...`, with
+# either absolute or repo-relative paths. If parsing fails we fall back
+# to the reported cwd (conservative: may block, never lets a bad commit
+# through).
 cwd=$(reviewq_jq '.cwd')
 [[ -z "$cwd" ]] && cwd=$(reviewq_project_dir)
+
+# Use bash builtin regex (BSD sed ERE support is inconsistent across
+# macOS versions — the portable path is in-process).
+cd_target=""
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\;\&\|]+) ]]; then
+    cd_target="${BASH_REMATCH[1]}"
+    cd_target="${cd_target%\"}"
+    cd_target="${cd_target#\"}"
+    cd_target="${cd_target%\'}"
+    cd_target="${cd_target#\'}"
+fi
+if [[ -n "$cd_target" ]]; then
+    case "$cd_target" in
+        /*) effective_cwd="$cd_target" ;;
+        *)  effective_cwd="$cwd/$cd_target" ;;
+    esac
+    if [[ -d "$effective_cwd" ]]; then
+        cwd="$effective_cwd"
+    fi
+fi
+
 [[ ! -d "$cwd" ]] && exit 0
 
 # The commit must happen inside a worktree. Worktree-gate covers edits but
@@ -85,6 +114,35 @@ if [[ -z "$staged" ]]; then
     exit 0
 fi
 rust_staged=$(printf '%s\n' "$staged" | grep -E '\.rs$' || true)
+
+# ---- 0. AGENTS.md size budget -------------------------------------------
+# Keep AGENTS.md under the harness-engineering Pointer Pattern ceiling so
+# it does not consume the whole context window before the first turn.
+# Source: nyosegawa harness-engineering-best-practices-2026 recommends
+# ≤50 lines of pointers; we allow up to 120 as a working ceiling because
+# the project's mistake / ADR logs live in this file and need room to
+# grow. Adjust AGENTS_MD_MAX if the project genuinely outgrows it.
+AGENTS_MD_MAX=${AGENTS_MD_MAX:-120}
+if printf '%s\n' "$staged" | grep -qx 'AGENTS.md'; then
+    lines=$(git -C "$cwd" show ":AGENTS.md" 2>/dev/null | wc -l | tr -d ' ')
+    if [[ -n "$lines" && "$lines" -gt "$AGENTS_MD_MAX" ]]; then
+        reviewq_block "AGENTS.md is $lines lines; the commit-gate budget is $AGENTS_MD_MAX.
+
+Harness-engineering best practice: keep the agent instructions file
+small and use the Pointer Pattern (reference .claude/rules/*.md files
+instead of inlining their content). A bloated AGENTS.md is loaded into
+every session's first turn and consumes context that could be used for
+actual work.
+
+Fix:
+  - Move inline sections into the matching .claude/rules/<topic>.md file
+    and leave a one-line pointer behind.
+  - If the content truly belongs in AGENTS.md (project-wide mistakes,
+    ADR shortlist), trim it to essentials.
+  - If the ceiling itself is wrong, raise AGENTS_MD_MAX in commit-gate.sh
+    with a justifying comment, in a dedicated chore/ worktree."
+    fi
+fi
 
 # ---- 1. cargo fmt --check -----------------------------------------------
 if ! (cd "$cwd" && cargo fmt --check >/tmp/reviewq-gate-fmt.log 2>&1); then

--- a/.claude/hooks/safety-gate.sh
+++ b/.claude/hooks/safety-gate.sh
@@ -106,16 +106,89 @@ Fix:
 fi
 
 # ---- Class 5: branch hard-delete ----
-if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+branch[[:space:]]+.*(-D|--delete[[:space:]]+--force)'; then
-    reviewq_block "'git branch -D' (force-delete) detected in: $cmd
+# We want to block `git branch -D` for UNMERGED branches but allow it when
+# the branch was squash-merged to main via a GitHub PR (`git branch -d`
+# refuses those because the SHA history differs even though the content
+# landed). Detection rules in order:
+#
+#   1. `git` must be at a command boundary (start, or after `;`, `&&`,
+#      `||`, `(`, `$(`, or a pipe). This avoids false positives when
+#      "git branch -D" appears inside a quoted string argument to `grep`
+#      or `echo`, which tripped the earlier, looser regex.
+#   2. Extract the target branch name from the command.
+#   3. If we can't parse it, block (conservative default).
+#   4. If a session marker `branch-delete-approved:<name>` exists, allow
+#      (explicit opt-in via /confirm-branch-delete slash command).
+#   5. If `gh pr list --head <name> --state merged` returns a merged PR,
+#      allow and log.
+#   6. Otherwise block with a helpful message that explains both escape
+#      hatches.
+if printf '%s' "$cmd" | grep -Eq '(^|[;&|(]|\$\()[[:space:]]*git[[:space:]]+branch[[:space:]]+[^"'"'"']*(-D|--delete[[:space:]]+--force)'; then
+    # Pull the branch name from the tail of the command. Accept any of:
+    #   git branch -D foo
+    #   git branch -Df foo
+    #   git branch --delete --force foo
+    #   git branch -D foo bar        (multiple — we check the first one)
+    target=$(printf '%s' "$cmd" | \
+        sed -E 's/.*git[[:space:]]+branch[[:space:]]+//' | \
+        awk '{
+            for (i = 1; i <= NF; i++) {
+                if ($i !~ /^-/) { print $i; exit }
+            }
+        }')
 
-Force-deletes branches with unmerged commits, losing the work.
+    allow=0
+    reason=""
 
-Fix:
-  - Use 'git branch -d <branch>' (lowercase) to delete only merged
-    branches; it will refuse to delete unmerged work.
-  - If you really need to discard unmerged work, open a PR first and
-    close it, so the ref is preserved in GitHub."
+    if [[ -z "$target" ]]; then
+        reason="could not parse branch name from command"
+    else
+        # Escape slashes for the marker filename — markers live in a flat
+        # directory so slashes need to become a safe separator.
+        safe_name=${target//\//__}
+
+        if reviewq_has_mark "branch-delete-approved:$safe_name"; then
+            allow=1
+            reason="session opt-in via /confirm-branch-delete"
+        elif command -v gh >/dev/null 2>&1; then
+            # Query GitHub for a merged PR on this branch. Suppress stderr
+            # so network / auth failures do not trip the soft-fail trap.
+            pr_state=$(gh pr list --head "$target" --state merged \
+                --json state --jq '.[0].state // empty' 2>/dev/null || true)
+            if [[ "$pr_state" == "MERGED" ]]; then
+                allow=1
+                reason="gh confirms a merged PR on head=$target"
+            fi
+        fi
+    fi
+
+    if [[ "$allow" -eq 1 ]]; then
+        reviewq_log_event allow "branch -D $target allowed: $reason"
+    else
+        reviewq_block "'git branch -D' (force-delete) detected in: $cmd
+
+Force-deleting a branch with unmerged commits discards work silently.
+The lowercase 'git branch -d <name>' refuses unmerged branches, but
+it also refuses branches that were *squash-merged* via a GitHub PR
+(because the SHAs differ even though the content landed on main).
+
+Fix — pick one depending on the branch state:
+  (a) Regular merge / rebase already landed → 'git branch -d <name>'
+      should already work. If it doesn't, your local main is stale:
+        git fetch origin && git branch -d <name>
+
+  (b) Squash-merged via GitHub PR → this gate will auto-unblock once
+      'gh' confirms the PR is MERGED. Make sure you're authenticated:
+        gh auth status
+        gh pr list --head <name> --state merged
+      Then retry the same 'git branch -D' command.
+
+  (c) Branch is genuinely unmerged and you want to discard the work →
+      run '/confirm-branch-delete <name>' to set the
+      'branch-delete-approved:<name>' session marker, then retry.
+      This is the only explicit opt-in path; it exists so destructive
+      deletes still require a human acknowledgement."
+    fi
 fi
 
 # ---- Class 6: piping remote scripts to a shell ----

--- a/.claude/hooks/tests/run-tests.sh
+++ b/.claude/hooks/tests/run-tests.sh
@@ -19,6 +19,15 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 HOOKS="$(cd "$HERE/.." && pwd)"
 REPO="$(cd "$HOOKS/../.." && pwd)"
 
+# Strip any git env vars that a wrapping pre-commit framework may have
+# set. Without this, tests that spin up a throwaway fake repo see the
+# wrapper's GIT_INDEX_FILE / GIT_DIR and look inside the *wrapper's*
+# index instead of the fake one. This caused AGENTS.md size gate tests
+# to spuriously fail when run via make all during a git commit.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE GIT_AUTHOR_DATE GIT_COMMITTER_DATE \
+      GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL \
+      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX
+
 export CLAUDE_PROJECT_DIR="$REPO"
 # Isolated session dir — we create a fresh session_id per test case so
 # tests never see stale markers from each other or from a real session.
@@ -222,6 +231,62 @@ runcase "block: 'git commit' from outside a worktree" commit-gate.sh 2 '{
 rm -rf "$FAKE_MAIN"
 cleanup_session "$SID"
 
+# AGENTS.md size budget: build a tiny fake git repo, stage a huge
+# AGENTS.md, and verify commit-gate blocks with a useful message.
+SID=$(scratch_session)
+FAKE_REPO=$(mktemp -d "${TMPDIR:-/tmp}/reviewq-agents-md-XXXXXX")
+# Pretend the repo lives under a .worktree/ path so the worktree check
+# passes and we exercise the size gate specifically.
+FAKE_WT="$FAKE_REPO/.worktree/fake-branch"
+mkdir -p "$FAKE_WT"
+(cd "$FAKE_WT" && git init -q && git config user.email 't@t' && git config user.name 't')
+# Write an AGENTS.md that is deliberately over the default 120-line ceiling.
+printf '# huge agents md\n\n%s\n' "$(yes 'pointer line' | head -200)" > "$FAKE_WT/AGENTS.md"
+(cd "$FAKE_WT" && git add AGENTS.md)
+# With no Rust staged, only the size check should block.
+out=$(printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git commit -m agents-md-grow"},
+  "cwd":"'"$FAKE_WT"'"
+}' | "$HOOKS/commit-gate.sh" 2>&1 >/dev/null)
+rc=$?
+if [[ "$rc" -eq 2 && "$out" == *"AGENTS.md is"* ]]; then
+    printf '  \e[32mPASS\e[0m block: AGENTS.md over size budget\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m AGENTS.md size gate did not fire (rc=%s)\n' "$rc"
+    FAIL=$((FAIL + 1))
+fi
+rm -rf "$FAKE_REPO"
+cleanup_session "$SID"
+
+# AGENTS.md under the budget should NOT fire the size gate. We still
+# exit non-zero eventually because the fake repo has no Cargo.toml, so
+# we just assert that "AGENTS.md is" does not appear in the output.
+SID=$(scratch_session)
+FAKE_REPO=$(mktemp -d "${TMPDIR:-/tmp}/reviewq-agents-md-XXXXXX")
+FAKE_WT="$FAKE_REPO/.worktree/fake-branch"
+mkdir -p "$FAKE_WT"
+(cd "$FAKE_WT" && git init -q && git config user.email 't@t' && git config user.name 't')
+printf '# small agents md\n\npointer line\n' > "$FAKE_WT/AGENTS.md"
+(cd "$FAKE_WT" && git add AGENTS.md)
+out=$(printf '%s' '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git commit -m agents-md-small"},
+  "cwd":"'"$FAKE_WT"'"
+}' | "$HOOKS/commit-gate.sh" 2>&1 >/dev/null)
+if [[ "$out" != *"AGENTS.md is"* ]]; then
+    printf '  \e[32mPASS\e[0m allow: small AGENTS.md does not trip size gate\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m small AGENTS.md wrongly tripped size gate\n'
+    FAIL=$((FAIL + 1))
+fi
+rm -rf "$FAKE_REPO"
+cleanup_session "$SID"
+
 echo "== mark-post-tool.sh =="
 
 SID=$(scratch_session)
@@ -404,10 +469,49 @@ runcase "allow: git clean -fd (no -x)" safety-gate.sh 0 '{
 cleanup_session "$SID"
 
 SID=$(scratch_session)
-runcase "block: git branch -D" safety-gate.sh 2 '{
+runcase "block: git branch -D (no approval, no merged PR)" safety-gate.sh 2 '{
   "session_id":"'"$SID"'",
   "tool_name":"Bash",
-  "tool_input":{"command":"git branch -D feat/x"},
+  "tool_input":{"command":"git branch -D feat/definitely-not-a-real-branch-xyz"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" "branch-delete-approved:feat__experimental"
+runcase "allow: git branch -D with session opt-in marker" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git branch -D feat/experimental"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" "branch-delete-approved:chore__harness-iter2"
+runcase "allow: git branch --delete --force with marker" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git branch --delete --force chore/harness-iter2"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+# Regression: "git branch -D" inside a quoted argument to grep must NOT
+# trip the gate. This was a real bug in iter1 that blocked grepping
+# historic commit messages, hook source, etc.
+SID=$(scratch_session)
+runcase "allow: grep for literal \"git branch -D\" string" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"grep -n \"git branch -D\" .claude/hooks/tests/run-tests.sh"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "allow: echo of \"git branch -D\" literal" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"echo \"safety-gate blocks git branch -D\""},
   "cwd":"'"$REPO"'"
 }'
 cleanup_session "$SID"

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,24 +1,86 @@
 # Git Workflow
 
-## Commit Message Format
+## ⚠️ Worktree requirement (non-negotiable)
+
+**NEVER commit directly to main.** Every development task — including
+single-file edits, typo fixes, and docs-only changes — MUST start by
+creating a dedicated `git worktree` under `.worktree/<branch-name>/`.
+Editing files in the main worktree is not allowed, even when the change
+looks trivial. This is mechanically enforced by `worktree-gate.sh`;
+see `.claude/hooks/README.md`.
+
+### Worktree procedure
+
+1. **Before any file edit**, create a worktree + feature branch from the
+   repo root (main worktree):
+   ```bash
+   git worktree add -b feat/your-feature-name .worktree/feat-your-feature-name
+   cd .worktree/feat-your-feature-name
+   ```
+   - Prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `refactor/`,
+     `perf/`, `test/`, `ci/` to match Conventional Commits.
+   - The directory name should mirror the branch with `/` → `-`.
+   - If you already started editing on main by mistake:
+     ```bash
+     git stash push -u
+     git worktree add -b <type>/<slug> .worktree/<type>-<slug>
+     git -C .worktree/<type>-<slug> stash pop
+     ```
+2. **Work inside the worktree**. All edits, tests, and builds happen
+   there. Never `cd` back to main mid-task.
+3. **After changes**, run quality checks inside the worktree:
+   ```bash
+   make all  # fmt + clippy -D warnings + test + test-hooks
+   ```
+4. **Update README.md** if user-facing behavior changed.
+5. **Commit** with a Conventional Commits message (see below).
+6. **Push + create PR** — never merge directly to main:
+   ```bash
+   git push -u origin <branch-name>
+   gh pr create
+   ```
+7. **Cleanup after merge**: run `/cleanup-worktree --restore-cwd --delete-branch`
+   from inside the worktree. `--restore-cwd` is required per the global
+   `~/.claude/CLAUDE.md` rule to keep the session's tools alive after
+   the directory is removed.
+
+### Pre-commit checklist
+
+- [ ] Working inside a `.worktree/<branch>` directory?
+- [ ] On a feature branch (not main)?
+- [ ] `make all` passes (fmt + clippy + test + test-hooks)?
+- [ ] README.md updated if user-facing behavior changed?
+- [ ] PR will be created?
+
+## Commit message format
+
 ```
-<type>: <description>
+<type>: <short description>
 
 <optional body>
 ```
 
-Types: feat, fix, refactor, docs, test, chore, perf, ci
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
 
-Note: Attribution disabled globally via ~/.claude/settings.json.
+All commit messages, PR titles, PR descriptions, and code comments must
+be written in English.
 
-## Pull Request Workflow
+Author attribution is disabled globally via `~/.claude/settings.json`;
+do not add `Signed-off-by` or `Co-authored-by` unless the user asks.
 
-When creating PRs:
-1. Analyze full commit history (not just latest commit)
-2. Use `git diff [base-branch]...HEAD` to see all changes
-3. Draft comprehensive PR summary
-4. Include test plan with TODOs
-5. Push with `-u` flag if new branch
+## Pull request workflow
 
-> For the full development process (planning, TDD, code review) before git operations,
-> see [development-workflow.md](./development-workflow.md).
+When creating a PR:
+
+1. Analyze the full commit history on the branch (not just the latest
+   commit).
+2. Use `git diff <base-branch>...HEAD` to see every change that will
+   land.
+3. Draft a PR summary that explains the *why*, not just the *what*.
+4. Include a test plan with concrete checklist items.
+5. Push with `-u origin <branch>` on the first push so the branch
+   tracks.
+
+See `.claude/rules/development-workflow.md` for the full feature
+pipeline (research → plan → TDD → review → commit) that precedes git
+operations.

--- a/.claude/rules/harness-engineering.md
+++ b/.claude/rules/harness-engineering.md
@@ -74,6 +74,7 @@ files; their presence encodes workflow state.
 | `e2e-done`              | Skill(reviewq-e2e) | commit-gate | TUI e2e completed |
 | `tests-just-passed`     | commit-gate after `cargo test` | stop-gate | skip redundant check |
 | `config-edit-approved`  | /config-edit slash command | config-protect-gate | config edits unlocked |
+| `branch-delete-approved:<safe_name>` | /confirm-branch-delete slash command | safety-gate (class 5) | force-delete of that specific branch unlocked once |
 
 ## Never bypass
 

--- a/.claude/rules/plan-first.md
+++ b/.claude/rules/plan-first.md
@@ -1,0 +1,26 @@
+# Plan-First Rule
+
+For changes touching **3 or more files** or introducing **new architectural
+patterns**:
+
+1. **Enter plan mode first** — use `EnterPlanMode` to explore the codebase
+   and design the approach before writing any code.
+2. **Get the plan approved** — the user must approve before execution
+   begins. The plan is the contract.
+3. **Include a verification strategy** — every plan must answer:
+   "How will we verify this works?" (tests, manual checks, CI gates, …).
+4. **Stop if scope drifts** — if the implementation diverges from the
+   approved plan, stop and re-plan rather than improvising.
+
+For small, well-scoped changes (single-file fix, typo, simple bug fix),
+skip the plan mode step and execute directly — but **still inside a
+fresh worktree** per `.claude/rules/git-workflow.md`. The worktree
+requirement has no size exemption.
+
+## Why
+
+`plan-and-handoff` / `blueprint` skills exist for this. Without a plan
+contract, the agent drifts mid-task, adds scope, and the result does
+not match what the user asked for. The three harness-engineering
+failure modes — drift, scope creep, silent corruption — are all
+mitigated by an explicit, approved plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,158 +1,81 @@
 # Agent Instructions
 
-## Project Overview
+**reviewq** is a Rust CLI/TUI that detects PRs where you are a requested
+reviewer and triggers AI code-review agents.
 
-**reviewq** is a CLI/TUI tool that automatically detects PRs where you are a requested reviewer and triggers AI code review agents.
+## Non-negotiable constraints
 
-## Build & Quality
+- **Work inside a `.worktree/<branch>/` directory**, always. Never edit
+  files in the main worktree. Mechanically enforced by
+  `.claude/hooks/worktree-gate.sh`. → full procedure:
+  `.claude/rules/git-workflow.md`.
+- **Read this file** (AGENTS.md) before the first edit — required by
+  `.claude/hooks/agents-md-gate.sh`.
+- **Invoke a routing skill** (`.claude/rules/skills.md`) before the
+  first `*.rs` edit — required by `.claude/hooks/skill-routing-gate.sh`.
+- **Write tests first** — production Rust edits are blocked until a
+  test file is touched or the `tdd-workflow` / `rust-testing` skill is
+  invoked (`.claude/hooks/tdd-gate.sh`).
+- **`make all` must be green before every commit** (fmt + clippy
+  `-D warnings` + test + test-hooks). Enforced by
+  `.claude/hooks/commit-gate.sh`.
+- **All commit messages, PR text, and code comments must be written in
+  English.** No exceptions.
+
+## Build & quality
 
 ```bash
-# REQUIRED: Run before completing any work
-make all          # format + lint + test
-
-# Individual commands
-make fmt          # cargo fmt
-make lint         # cargo clippy -- -D warnings
-make test         # cargo test
-
-# Workflow-enforcement hook self-tests (see .claude/hooks/README.md)
-make test-hooks
+make all          # fmt + lint + test + test-hooks   ← run before every commit
+make test-hooks   # workflow-enforcement hook self-tests
 ```
 
-## Workflow Enforcement Hooks
+Individual targets: `make fmt` / `make lint` / `make test` / `make build`.
 
-`.claude/hooks/` contains **mechanically enforced** gates wired into
-`.claude/settings.json` that block tool calls when the workflow below
-is not being followed. They exist because soft guidance in
-`CLAUDE.md` and `.claude/rules/` was historically skipped.
+Rust 2024 edition. `cargo clippy -- -D warnings`. Format with `cargo fmt`.
 
-| Gate | Blocks when … |
-|------|----------------|
-| `worktree-gate.sh` | Editing any file in the main reviewq worktree outside `.worktree/**` (only `.claude/hooks/**` is allowed, for bootstrap). |
-| `agents-md-gate.sh` | Any edit before this `AGENTS.md` has been `Read` in the current session. |
-| `skill-routing-gate.sh` | Editing any `*.rs` file before any `Skill()` call has been made this session. |
-| `commit-gate.sh` | `git commit` when `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` fails, when the commit is from outside a `.worktree/`, when `*.rs` files are staged without a `rust-review-done` marker, or when `src/tui/**` files are staged without an `e2e-done` marker. |
+## Where to find the detailed rules
 
-Markers are set automatically by `mark-post-tool.sh` (a PostToolUse
-dispatcher) when the matching tool runs. They are session-scoped under
-`.claude/.session/<session_id>/` and discarded at session end.
+| Topic | File |
+|-------|------|
+| Git worktree + commit + PR procedure | `.claude/rules/git-workflow.md` |
+| Full feature pipeline (research → plan → TDD → review → commit) | `.claude/rules/development-workflow.md` |
+| Plan-first rule (≥3 files or new patterns) | `.claude/rules/plan-first.md` |
+| Skill routing table (ECC + rust-skills) | `.claude/rules/skills.md` |
+| Agent orchestration (which agent for what) | `.claude/rules/agents.md` |
+| Rust coding style / patterns / testing / security | `.claude/rules/coding-style.md`, `.claude/rules/patterns.md`, `.claude/rules/testing.md`, `.claude/rules/security.md` |
+| Harness-engineering theory behind the hooks | `.claude/rules/harness-engineering.md` |
+| Every hook's purpose + marker vocabulary | `.claude/hooks/README.md` |
+| Model selection / context budgeting | `.claude/rules/performance.md` |
 
-**Never bypass these hooks.** The global `~/.claude/CLAUDE.md` forbids
-`--no-verify` and any hook disable. If a gate is wrong, patch the
-hook in a `chore/` worktree and re-run `make test-hooks`.
+## Project structure
 
-## Git Workflow (MUST FOLLOW)
+<!-- Keep this section short; point to rules files for details. -->
 
-⚠️ **NEVER commit directly to main. Always use a git worktree on a feature branch.**
+- `src/main.rs` — CLI entry point.
+- `src/tui/**` — ratatui TUI (see `.claude/rules/skills.md` for the
+  `reviewq-e2e` skill that must run on TUI changes).
+- `src/` — everything else is domain-separated by folder (jobs, repos,
+  executor, …).
+- `.claude/hooks/` — mechanically enforced workflow gates.
+- `.claude/rules/` — referenced by this file; the source of truth for
+  *how* to do each phase of work.
 
-**Every development task — including single-file edits, typo fixes, and docs-only changes — MUST start by creating a dedicated `git worktree` under `.worktree/<branch-name>/`.** Editing files in the main worktree is not allowed, even when the change looks trivial. This is intentional: it keeps main clean, makes parallel work safe, and matches the `cleanup-worktree` rules in the global `~/.claude/CLAUDE.md`.
+## Known mistakes & lessons learned
 
-1. **BEFORE any file edit or code change**: Create a worktree + feature branch
-   ```bash
-   # From the repo root (main worktree)
-   git worktree add -b feat/your-feature-name .worktree/feat-your-feature-name
-   cd .worktree/feat-your-feature-name
-   ```
-   - Use `feat/`, `fix/`, `docs/`, `chore/`, `refactor/` prefixes to match Conventional Commits.
-   - The worktree directory name should mirror the branch (slashes replaced with `-`).
-   - If you have already started editing on main by mistake, stop, `git stash push -u`, create the worktree, then `git -C .worktree/<name> stash pop` before continuing.
-2. **Work inside the worktree**: All edits, tests, and builds happen there. Never `cd` back to the main worktree to edit files mid-task.
-3. **After changes**: Run quality checks inside the worktree
-   ```bash
-   make all  # format + lint + test
-   ```
-4. **Update documentation**: If user-facing behavior changes, update README.md (still inside the worktree).
-5. **Commit**: Use conventional commits (feat:, fix:, docs:, etc.).
-6. **Push and create PR**: Never merge directly to main
-   ```bash
-   git push -u origin <branch-name>
-   gh pr create
-   ```
-7. **Cleanup**: When the PR is merged (or abandoned), run `/cleanup-worktree --restore-cwd --delete-branch` from the worktree to remove it. `--restore-cwd` is required per the global CLAUDE.md rule to keep the session's tools alive.
+Record AI-generated mistakes and the rule that prevents recurrence.
+Newest first. Keep each entry ≤5 lines so this section does not bloat.
 
-### Pre-Commit Checklist
+<!-- ### YYYY-MM-DD: short description -->
+<!-- - What happened: … -->
+<!-- - Root cause: … -->
+<!-- - Rule: the constraint that prevents recurrence. -->
 
-Before committing, verify:
-- [ ] Working inside a `.worktree/<branch>` directory (not the main worktree)?
-- [ ] On a feature branch (not main)?
-- [ ] `make all` passes?
-- [ ] README.md updated if needed?
-- [ ] PR will be created?
+## Architecture decisions
 
-## Instructions for AI Agents
+Short ADR notes that explain *why* the code is the way it is. Full ADRs
+go under `docs/adr/` when we add them; this section is for quick refs.
 
-- Before committing, ALWAYS re-read this Workflow section
-- **At the start of every task that touches the filesystem, check `git worktree list` and `git rev-parse --show-toplevel` first. If the cwd is the main worktree (or you are on `main`), stop and create a new worktree per the Git Workflow section before editing anything.**
-- When user says "commit", first verify you are inside a `.worktree/<branch>` directory on a feature branch. If not, create the worktree (stashing any accidental changes) before committing.
-- When user-facing behavior changes, proactively update README.md before committing
-- **All code comments, commit messages, PR titles, PR descriptions, and review comments MUST be written in English**
-
-### Plan-First Rule
-
-For changes touching **3 or more files** or introducing **new architectural patterns**:
-
-1. **Enter plan mode first** — use `EnterPlanMode` to explore the codebase and design the approach before writing any code.
-2. **Get the plan approved** — the user must approve before execution begins. The plan is the contract.
-3. **Include a verification strategy** — every plan must answer: "How will we verify this works?" (tests, manual checks, CI gates, etc.)
-4. **Stop if scope drifts** — if the implementation diverges from the approved plan, stop and re-plan rather than improvising.
-
-For small, well-scoped changes (single-file fixes, typo corrections, simple bug fixes), skip the plan mode step and execute directly — but **still inside a fresh worktree** per the Git Workflow above. The worktree requirement has no size exemption.
-
-### Proactive Skill Usage (ECC + rust-skills)
-
-This project bundles 127+ skills from [Everything Claude Code](https://github.com/affaan-m/everything-claude-code). Claude MUST proactively invoke the skills listed in [`.claude/rules/skills.md`](./.claude/rules/skills.md) — that file is the binding routing table for every development task. Read it at the start of each session and follow the phase-based defaults without waiting for explicit user instructions.
-
-Quick reference (see `skills.md` for the full routing table):
-
-- **Plan:** `plan-and-handoff`, `blueprint`, `architecture-decision-records`
-- **Research (before any new code):** `search-first`, `documentation-lookup`
-- **Implement:** `rust-patterns`, `rust-async-patterns`, `rust-skills:coding-guidelines`, `rust-skills:m01-ownership` / `m06-error-handling` / `m07-concurrency` as applicable
-- **Test (TDD first):** `tdd-workflow`, `rust-testing`, `reviewq-e2e` for TUI changes
-- **Review & verify (pre-commit):** `rust-review`, `security-review`, `verification-loop`, `quality-gate`
-- **Ship:** `create-branch`, `commit-oss`, `cleanup-worktree --restore-cwd`
-- **Continuous:** `strategic-compact`, `context-budget`, `continuous-learning-v2`
-
-These rust-skills in particular are NOT auto-triggered by hooks and must be used proactively:
-
-- `rust-skills:sync-crate-skills` — Run after adding/updating dependencies in Cargo.toml
-- `rust-skills:docs` — Use to look up crate API documentation from docs.rs
-- `rust-skills:coding-guidelines` — Reference when reviewing or writing Rust code style
-
-## Code Style
-
-- Rust 2024 edition
-- Use `cargo fmt` for formatting
-- All clippy warnings treated as errors (`-D warnings`)
-
-## Testing
-
-- Run single test: `cargo test test_name`
-- Run all tests: `cargo test` or `make test`
-- Tests located alongside source in same module or in tests/ directory
-
-## Project Structure
-
-<!-- Update as the codebase grows -->
-
-- `src/main.rs` — Application entry point
-
-## Known Mistakes & Lessons Learned
-
-Record AI-generated mistakes and the rules that prevent them from recurring. Update this section after every code review where the AI got something wrong.
-
-<!-- Add entries in reverse-chronological order (newest first) -->
-<!-- Format: ### YYYY-MM-DD: Short description -->
-<!-- - **What happened**: ... -->
-<!-- - **Root cause**: ... -->
-<!-- - **Rule**: The constraint to prevent recurrence -->
-
-## Architecture Decisions
-
-Key design choices and their rationale. Helps AI agents understand *why* things are the way they are, not just *what* they are.
-
-<!-- Add entries as architectural decisions are made -->
-<!-- Format: ### Decision title -->
-<!-- - **Context**: ... -->
-<!-- - **Decision**: ... -->
-<!-- - **Alternatives considered**: ... -->
-<!-- - **Trade-off**: ... -->
+<!-- ### Decision title -->
+<!-- - Context: … -->
+<!-- - Decision: … -->
+<!-- - Trade-off: … -->


### PR DESCRIPTION
## Summary

Iteration 2 on the workflow-enforcement hooks from #37. Addresses five issues that surfaced the first time the harness was used in anger:

1. **safety-gate false positive**: the branch force-delete class (class 5) blocked legitimate deletes of squash-merged PR branches (because `git branch -d` refuses them — SHAs differ even though content landed) with no escape hatch. The regex was also loose enough to match the literal substring inside a `grep` argument, so grepping a commit message or hook source containing the phrase was blocked.
2. **commit-gate wrong cwd**: the worktree check used the hook input `.cwd` field, which reflects Claude Code's persistent session cwd rather than the post-`cd` effective cwd. Commits composed as `cd .worktree/branch && git commit ...` from a session started in main were wrongly blocked.
3. **AGENTS.md had grown to 158 lines**, well past the harness-engineering ≤50-line pointer-pattern recommendation. `session-start.sh` was already warning on every session load.
4. **No drift prevention**: nothing stopped AGENTS.md from growing back.
5. **Hook tests leaked pre-commit framework env vars**: fake-repo tests that exercised `git -C <fake>` were reading the wrapping pre-commit framework's `GIT_INDEX_FILE` and inspecting the wrapper's index instead of the fake one, causing spurious failures under `make all` during a commit.

## Changes

### `safety-gate.sh` — branch force-delete class

- **Tighten regex** to require `git` at a command boundary (start of line, or after `;` / `&&` / `||` / `(` / `$(` / pipe). Quoted occurrences inside `grep` / `echo` / `sed` arguments no longer trip. Regression tests assert this.
- **Squash-merge detection**: allow the force-delete form when either
  - (a) a session marker `branch-delete-approved:<safe_name>` is present, or
  - (b) `gh pr list --head <name> --state merged` confirms a merged PR on that branch.
- **New `/confirm-branch-delete` slash command** that sets the session marker for explicit human opt-in on unmerged branches.

### `commit-gate.sh`

- **Parse `cd <path>` prefix**: when the command looks like `cd X && git commit ...` or `cd X; git commit ...`, parse `X` off the command with a bash builtin regex and use it as the effective cwd for both the worktree check and the cargo invocations. Uses `=~` (bash) instead of `sed -E` because BSD sed's ERE support is inconsistent across macOS versions.
- **AGENTS.md size budget gate**: when `AGENTS.md` is staged, block the commit if the staged version exceeds `AGENTS_MD_MAX` lines (default 120, overridable via env var). The ceiling is intentionally higher than the pointer-pattern ideal of 50 to leave room for the Mistakes / ADR log sections, but low enough to catch a full-scale drift back to inline documentation.

### `AGENTS.md` trim: 158 → 81 lines

Inline sections replaced with pointers to `.claude/rules/*.md`:

- Git Workflow → `.claude/rules/git-workflow.md` (source of truth)
- Plan-First Rule → **new** `.claude/rules/plan-first.md`
- Proactive Skill Usage → `.claude/rules/skills.md` (routing table already lived there)

What stays in AGENTS.md: project overview, non-negotiable constraints, build commands, a "Where to find the rules" table, project structure, and the empty Known Mistakes / ADR templates (reserved for project memory).

### `.claude/rules/git-workflow.md`

Now holds the full worktree workflow (create → work inside → make all → update README → commit → push+PR → cleanup), pre-commit checklist, commit-message format, and PR workflow. This was previously inlined in AGENTS.md.

### `.claude/rules/plan-first.md` (new)

The ≥3-file / new-pattern plan-first rule moved out of AGENTS.md verbatim, with a "Why" section tying it back to the three harness-engineering failure modes (drift, scope creep, silent corruption).

### Hook tests

- **Unset `GIT_INDEX_FILE` + friends** at the top of `run-tests.sh` so fake-repo tests do not leak the wrapping pre-commit framework's git context.
- **+6 test cases** (58/58 passing total):
  - branch force-delete blocked with no approval
  - branch force-delete allowed with session marker (lowercase `-D`)
  - branch force-delete allowed with session marker (`--delete --force`)
  - `grep "git branch -D"` literal string not blocked (regression)
  - `echo "... git branch -D ..."` literal string not blocked (regression)
  - AGENTS.md over budget blocks with "AGENTS.md is N lines" message
  - AGENTS.md under budget does not trip the gate

### `harness-engineering.md`

Document the new `branch-delete-approved:<safe_name>` marker in the marker vocabulary table.

## Test plan

- [x] `make test-hooks` — 58/58 (52 from iter1 + 6 new)
- [x] `cargo test` — 215 passing
- [x] `make all` — green (fmt + clippy -D warnings + test + test-hooks)
- [x] Commit of this branch actually succeeded through the new hooks (end-to-end smoke test of the cd-prefix parse fix — this was blocked on the un-patched iter1 hooks before)
- [ ] After merge, verify `git branch -D chore/hardened-workflow-hooks` (the stranded iter1 branch) is auto-allowed by `gh` detecting MERGED state
- [ ] After merge, verify session-start's "AGENTS.md is getting long" warning stops firing

## Files changed

```
.claude/commands/confirm-branch-delete.md  (new)
.claude/hooks/commit-gate.sh               (cd-parse + AGENTS.md size gate)
.claude/hooks/safety-gate.sh               (class 5 rewrite)
.claude/hooks/tests/run-tests.sh           (env var unset + 6 new cases)
.claude/rules/git-workflow.md              (full worktree workflow moved in)
.claude/rules/harness-engineering.md       (marker vocab + 1 row)
.claude/rules/plan-first.md                (new)
AGENTS.md                                  (158 -> 81 lines)
```

8 files changed, 463 insertions(+), 163 deletions(-).