### PR TITLE
chore: harness iter3 — safety-gate allows git global options, fsmonitor cleanup

### DIFF
--- a/.claude/hooks/safety-gate.sh
+++ b/.claude/hooks/safety-gate.sh
@@ -32,6 +32,28 @@ tool_name=$(reviewq_jq '.tool_name')
 cmd=$(reviewq_jq '.tool_input.command')
 [[ -z "$cmd" ]] && exit 0
 
+# GIT_SUBCMD_PREFIX matches `git` at a shell-command boundary (start of
+# string, or after `;`, `&&`, `||`, `(`, `$(`, or a pipe), optionally
+# followed by up to 4 whitespace-separated "gap" tokens. The gap tokens
+# exist so the classes below recognise git invocations with global
+# options between `git` and the subcommand — e.g. all of:
+#
+#   git push --force origin main
+#   git -C /some/path push --force
+#   git --git-dir=.git --work-tree=. push --force
+#   git -c user.name=x push --force
+#
+# Gap tokens are constrained to not contain quote characters, so a
+# literal occurrence of "git branch -D" inside an argument to `grep`,
+# `echo`, or `sed` does NOT trip the gate. The 4-token ceiling is a
+# pragmatic bound: if you legitimately need more than 4 global options
+# between git and a destructive subcommand, you are doing something
+# unusual enough that the false-positive block is acceptable.
+#
+# This regex is a string (not a bash variable with special meaning); it
+# is interpolated into each class's grep pattern below.
+GIT_SUBCMD_PREFIX='(^|[;&|(]|\$\()[[:space:]]*git([[:space:]]+[^[:space:]"'"'"']+){0,4}[[:space:]]+'
+
 # ---- Class 1: indiscriminate rm ----
 # Block `rm -rf /`, `rm -rf ~`, `rm -rf *`, `rm -rf /*`, `rm -rf .`.
 # We use word-boundary regex so things like `rmdir` or `./rm` don't trip.
@@ -49,10 +71,10 @@ Fix:
 fi
 
 # ---- Class 2: force-push ----
-if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]]+.*(--force([[:space:]]|$)|-f([[:space:]]|$))'; then
+if printf '%s' "$cmd" | grep -Eq "${GIT_SUBCMD_PREFIX}push[[:space:]]+[^\"']*(--force([[:space:]]|\$)|-f([[:space:]]|\$))"; then
     # Allow --force-with-lease (safer) as an escape hatch for intentional
     # rewrites of a feature branch the user owns.
-    if ! printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]]+.*--force-with-lease'; then
+    if ! printf '%s' "$cmd" | grep -Eq "${GIT_SUBCMD_PREFIX}push[[:space:]]+[^\"']*--force-with-lease"; then
         reviewq_block "'git push --force' / 'git push -f' detected: $cmd
 
 Force-push rewrites remote history and can destroy other contributors'
@@ -80,7 +102,7 @@ Fix:
 fi
 
 # ---- Class 4: hard reset / destructive git clean ----
-if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+reset[[:space:]]+(--hard|.*[[:space:]]--hard)'; then
+if printf '%s' "$cmd" | grep -Eq "${GIT_SUBCMD_PREFIX}reset[[:space:]]+[^\"']*--hard"; then
     reviewq_block "'git reset --hard' detected in: $cmd
 
 Hard-reset discards uncommitted work and rewrites the index silently.
@@ -93,7 +115,7 @@ Fix:
   - Use 'git reset --keep <ref>' to reset while aborting on conflicts."
 fi
 
-if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+clean[[:space:]]+.*(-[A-Za-z]*f[A-Za-z]*x|-[A-Za-z]*x[A-Za-z]*f)'; then
+if printf '%s' "$cmd" | grep -Eq "${GIT_SUBCMD_PREFIX}clean[[:space:]]+[^\"']*(-[A-Za-z]*f[A-Za-z]*x|-[A-Za-z]*x[A-Za-z]*f)"; then
     reviewq_block "'git clean -fdx' (or -fx) detected in: $cmd
 
 This deletes EVERY untracked file including .gitignored build artifacts,
@@ -123,14 +145,20 @@ fi
 #      allow and log.
 #   6. Otherwise block with a helpful message that explains both escape
 #      hatches.
-if printf '%s' "$cmd" | grep -Eq '(^|[;&|(]|\$\()[[:space:]]*git[[:space:]]+branch[[:space:]]+[^"'"'"']*(-D|--delete[[:space:]]+--force)'; then
+if printf '%s' "$cmd" | grep -Eq "${GIT_SUBCMD_PREFIX}branch[[:space:]]+[^\"']*(-D|--delete[[:space:]]+--force)"; then
     # Pull the branch name from the tail of the command. Accept any of:
     #   git branch -D foo
+    #   git -C repo branch -D foo
+    #   git --git-dir=.git --work-tree=. branch -D foo
     #   git branch -Df foo
     #   git branch --delete --force foo
     #   git branch -D foo bar        (multiple — we check the first one)
+    #
+    # Strip everything up to and including the `branch` keyword (with
+    # any intervening global options), then take the first positional
+    # token that does not start with `-`.
     target=$(printf '%s' "$cmd" | \
-        sed -E 's/.*git[[:space:]]+branch[[:space:]]+//' | \
+        sed -E 's/.*git([[:space:]]+[^[:space:]"'"'"']+)*[[:space:]]+branch[[:space:]]+//' | \
         awk '{
             for (i = 1; i <= NF; i++) {
                 if ($i !~ /^-/) { print $i; exit }

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -51,6 +51,34 @@ for _ in 1 2 3 4; do
 done
 cwd="$probe"
 
+# --- stale-state cleanup --------------------------------------------------
+# git worktree admin dirs and fsmonitor daemons routinely get left behind
+# when a previous session removed a worktree but git internals did not
+# fully reconcile. Symptoms seen in iter2: `git rev-parse --show-toplevel`
+# returns a deleted worktree path, `git checkout` fails with "fatal: this
+# operation must be run in a work tree", and the AGENTS.md size gate
+# test picks up a stale index from a wrapper framework.
+#
+# Best-effort fixes on every session start:
+#   1. Prune stale worktree admin dirs. Safe and fast.
+#   2. Stop any fsmonitor daemon pointing at a now-deleted path. Only
+#      fires when the daemon is alive; silent no-op otherwise.
+cleanup_log=$(reviewq_session_dir)/session-start-cleanup.log
+{
+    echo "== session-start stale-state cleanup =="
+    (cd "$cwd" && git worktree prune -v 2>&1) || true
+    # `git fsmonitor--daemon stop` exits non-zero if no daemon is running;
+    # `|| true` keeps the session bootstrap from soft-failing open.
+    (cd "$cwd" && git fsmonitor--daemon stop 2>&1) || true
+    # Also remove the IPC socket if it still exists without a live daemon.
+    if [[ -S "$cwd/.git/fsmonitor--daemon.ipc" ]]; then
+        if ! pgrep -f "fsmonitor--daemon.*$cwd" >/dev/null 2>&1; then
+            rm -f "$cwd/.git/fsmonitor--daemon.ipc"
+            echo "removed stale fsmonitor ipc socket"
+        fi
+    fi
+} > "$cleanup_log" 2>&1 || true
+
 # --- collect context snippets --------------------------------------------
 status_lines=$( (cd "$cwd" && git status --short --branch) 2>/dev/null | head -20 )
 log_lines=$( (cd "$cwd" && git log --oneline -15) 2>/dev/null )

--- a/.claude/hooks/tests/run-tests.sh
+++ b/.claude/hooks/tests/run-tests.sh
@@ -516,6 +516,77 @@ runcase "allow: echo of \"git branch -D\" literal" safety-gate.sh 0 '{
 }'
 cleanup_session "$SID"
 
+# iter3: git with global options between `git` and the subcommand
+# (e.g. `git -C path branch -D foo`, `git --git-dir=X branch -D foo`)
+# must also trip the gate. The iter2 regex required `git branch` to be
+# directly adjacent, which silently let these forms through.
+
+SID=$(scratch_session)
+runcase "block: git -C path branch -D (iter3)" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git -C /tmp/repo branch -D feat/bogus-xyz"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git --git-dir=X branch -D (iter3)" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git --git-dir=/tmp/r/.git --work-tree=/tmp/r branch -D feat/bogus-xyz"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git -c key=val push --force (iter3)" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git -c user.name=x push --force origin main"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git -C path reset --hard (iter3)" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git -C /tmp/repo reset --hard HEAD~3"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session)
+runcase "block: git -C path clean -fdx (iter3)" safety-gate.sh 2 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git -C /tmp/repo clean -fdx"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+SID=$(scratch_session); mark_for_session "$SID" "branch-delete-approved:feat__scoped"
+runcase "allow: git -C path branch -D with marker (iter3)" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git -C /tmp/repo branch -D feat/scoped"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
+# Regression: `git log` with a non-option argument should NOT trip any
+# class 2/4/5 gate even though it shares the GIT_SUBCMD_PREFIX path —
+# none of the subcommand keywords match.
+SID=$(scratch_session)
+runcase "allow: git log --oneline origin/main (iter3)" safety-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "tool_name":"Bash",
+  "tool_input":{"command":"git log --oneline origin/main"},
+  "cwd":"'"$REPO"'"
+}'
+cleanup_session "$SID"
+
 SID=$(scratch_session)
 runcase "block: curl | sh" safety-gate.sh 2 '{
   "session_id":"'"$SID"'",

--- a/.claude/rules/harness-engineering.md
+++ b/.claude/rules/harness-engineering.md
@@ -98,3 +98,34 @@ the current session at any time. The log is session-scoped and does
 not persist across sessions — for long-lived debugging, copy relevant
 lines into `.claude/state/PROGRESS.md`.
 
+## Known git worktree gotchas
+
+Removing a worktree does **not** always clean up git's internal state
+cleanly on macOS:
+
+- **fsmonitor daemon survival**: if `git worktree remove` runs while a
+  per-worktree `fsmonitor--daemon` is still alive, the daemon keeps
+  running and pointing at the deleted path. Subsequent `git rev-parse
+  --show-toplevel` calls from anywhere in the repo may return the
+  deleted path, and `git checkout -- .` fails with *"fatal: this
+  operation must be run in a work tree"*.
+- **stale admin dir**: the `.git/worktrees/<name>/` dir can be left
+  behind with dangling `gitdir` pointer.
+- **stale IPC socket**: `.git/fsmonitor--daemon.ipc` can point at a
+  dead daemon.
+
+`session-start.sh` now runs a best-effort cleanup on every session
+bootstrap: `git worktree prune`, `git fsmonitor--daemon stop`, and
+removal of a dangling IPC socket. Output is logged under
+`.claude/.session/<session_id>/session-start-cleanup.log`.
+
+If you hit this mid-session, the manual recovery is:
+
+```bash
+git worktree prune
+git fsmonitor--daemon stop || true
+rm -f .git/fsmonitor--daemon.ipc
+# Or: disable fsmonitor on this repo entirely
+git config core.fsmonitor false
+```
+


### PR DESCRIPTION
## Summary

Iteration 3 on the workflow-enforcement hooks from #37 / #38. Fixes two bugs that surfaced while cleaning up after the iter2 merge:

1. **`safety-gate` missed git invocations with global options.** Classes 2 (force push), 4 (hard-reset / destructive clean), and 5 (branch force-delete) required the subcommand keyword to be directly adjacent to `git`. When git was invoked with a global option first — `git -C /path branch -D foo`, `git --git-dir=X --work-tree=Y push --force`, `git -c user.name=x reset --hard` — the regex silently dropped to the fallthrough "bash command cleared safety checks" path and let the destructive operation through. This was not theoretical: the iter2 cleanup phase deleted merged branches using exactly this form, and the hook log confirmed the `gh` merge auto-detect was **never reached**.

2. **`fsmonitor--daemon` outlived the worktree it was tracking.** `git worktree remove` does not always stop the per-worktree fsmonitor daemon. When it doesn't, `git rev-parse --show-toplevel` from the main worktree returns the **deleted** path, `git checkout -- .` fails with *"fatal: this operation must be run in a work tree"*, and the stale `.git/fsmonitor--daemon.ipc` socket makes the issue persist across shell invocations. Observed mid-session in the iter2 cleanup phase.

## Changes

### `safety-gate.sh` — `GIT_SUBCMD_PREFIX`

New shared regex fragment near the top of the file:

```bash
GIT_SUBCMD_PREFIX='(^|[;&|(]|\$\()[[:space:]]*git([[:space:]]+[^[:space:]"'"'"']+){0,4}[[:space:]]+'
```

It matches `git` at a shell-command boundary (start, `;`, `&&`, `||`, `(`, `$(`, or pipe), optionally followed by up to 4 whitespace-separated "gap" tokens that exclude quote characters. This lets the destructive-command classes recognise `git -C path`, `git --git-dir=X`, `git -c key=val` invocations without producing false positives inside quoted `grep` / `echo` / `sed` arguments, and without matching unrelated subcommands like `git log --oneline origin/main`.

All 4 destructive-command classes now interpolate `${GIT_SUBCMD_PREFIX}` ahead of the subcommand keyword:

- **Class 2** (force push): both the main detection and the `--force-with-lease` exemption.
- **Class 4** (hard-reset).
- **Class 4b** (destructive `git clean` variants with `-x`).
- **Class 5** (branch force-delete): detection regex **and** the `sed` expression that extracts the branch name for the `gh pr list --head <name> --state merged` auto-allow path.

### `session-start.sh` — stale-state cleanup

New best-effort cleanup block that runs on every `SessionStart` before emitting the git-status context:

```bash
cleanup_log=$(reviewq_session_dir)/session-start-cleanup.log
{
    echo "== session-start stale-state cleanup =="
    (cd "$cwd" && git worktree prune -v 2>&1) || true
    (cd "$cwd" && git fsmonitor--daemon stop 2>&1) || true
    if [[ -S "$cwd/.git/fsmonitor--daemon.ipc" ]]; then
        if ! pgrep -f "fsmonitor--daemon.*$cwd" >/dev/null 2>&1; then
            rm -f "$cwd/.git/fsmonitor--daemon.ipc"
            echo "removed stale fsmonitor ipc socket"
        fi
    fi
} > "$cleanup_log" 2>&1 || true
```

- `git worktree prune -v` removes dangling admin dirs.
- `git fsmonitor--daemon stop` kills the per-worktree daemon; silent no-op if nothing is running.
- Dangling `.git/fsmonitor--daemon.ipc` sockets are removed only when no matching process is alive.
- Output is logged under `.claude/.session/<session_id>/session-start-cleanup.log` for audit, never blocks the session, swallows all errors.

### `harness-engineering.md` — "Known git worktree gotchas"

New section documenting:

- The fsmonitor daemon lifecycle issue (what it looks like mid-session).
- Stale worktree admin dirs.
- Stale IPC sockets.
- The manual recovery path, including the nuclear `git config core.fsmonitor false` option for this repo.

## Test plan

- [x] `bash -n` syntax check on all edited hooks.
- [x] `make test-hooks` — **65/65** passing (58 from iter2 + 7 new iter3 cases).
- [x] `cargo test` — 215 passing.
- [x] `make all` — green.
- [ ] After merge, verify `session-start.sh` actually kills stale fsmonitor daemons on a fresh session (can only be confirmed live).
- [ ] After merge, verify the next `git -C path branch -D <merged-branch>` is correctly handled by the `gh pr list` auto-allow path instead of the fallthrough allow.

## New test cases

All exercising the `GIT_SUBCMD_PREFIX` path:

| Test | Expected |
|------|----------|
| `git -C /tmp/repo branch -D feat/bogus-xyz` | **block** (class 5, no marker, no merged PR) |
| `git --git-dir=/tmp/r/.git --work-tree=/tmp/r branch -D feat/bogus-xyz` | **block** (class 5) |
| `git -c user.name=x push --force origin main` | **block** (class 2) |
| `git -C /tmp/repo reset --hard HEAD~3` | **block** (class 4) |
| `git -C /tmp/repo clean -fdx` | **block** (class 4b) |
| `git -C /tmp/repo branch -D feat/scoped` with `branch-delete-approved:feat__scoped` marker | **allow** (class 5 opt-in) |
| `git log --oneline origin/main` | **allow** (regression — no class triggers) |

## Files changed

```
.claude/hooks/safety-gate.sh         (GIT_SUBCMD_PREFIX + 4 class updates + sed fix)
.claude/hooks/session-start.sh       (stale-state cleanup block)
.claude/hooks/tests/run-tests.sh     (+7 test cases)
.claude/rules/harness-engineering.md (Known git worktree gotchas section)
```

4 files changed, 164 insertions(+), 6 deletions(-).
