### PR TITLE
test(tui): replace e2e-done marker with TestBackend render tests

### DIFF
--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -198,18 +198,12 @@ finishes, unblocking this gate. Staged Rust files:
 $(printf '  %s\n' $rust_staged)"
 fi
 
-# ---- 5. e2e marker (only when src/tui/** files are staged) --------------
-tui_staged=$(printf '%s\n' "$staged" | grep -E '^src/tui/' || true)
-if [[ -n "$tui_staged" ]] && ! reviewq_has_mark e2e-done; then
-    reviewq_block "TUI files staged but reviewq-e2e has not run this session.
-
-.claude/rules/skills.md → Phase 4: 'TUI behavior changes (src/tui/**) → reviewq-e2e'
-
-Fix: run the e2e workflow, then retry the commit.
-  Skill(reviewq-e2e)
-
-Once the e2e run marker is set, this gate will unblock."
-fi
+# TUI e2e coverage was previously gated via an `e2e-done` session marker
+# set by the reviewq-e2e skill. That marker was only proof that the skill
+# was loaded, not that any interactive test actually ran, so it was
+# trivially bypassable. It has been retired in favor of `tests/tui_render.rs`,
+# which drives every view's render function through ratatui's TestBackend
+# as part of the standard `cargo test` pass above. No marker required.
 
 # All gates passed.
 exit 0

--- a/.claude/hooks/mark-post-tool.sh
+++ b/.claude/hooks/mark-post-tool.sh
@@ -16,9 +16,6 @@
 #                          or the rust-review skill finished. Unlocks
 #                          the rust-review check in commit-gate.sh.
 #
-#   e2e-done             — reviewq-e2e skill was invoked. Unlocks the
-#                          TUI e2e check in commit-gate.sh.
-#
 #   tdd-tests-written    — tdd-workflow / rust-testing skill was invoked,
 #                          OR a test file has been edited this session.
 #                          Unlocks tdd-gate.sh.
@@ -84,9 +81,6 @@ case "$tool_name" in
             safe=$(printf '%s' "$skill_name" | tr '/:' '__')
             reviewq_mark "skill:$safe"
             case "$skill_name" in
-                reviewq-e2e)
-                    reviewq_mark e2e-done
-                    ;;
                 rust-testing|tdd-workflow)
                     reviewq_mark tdd-tests-written
                     ;;

--- a/.claude/rules/harness-engineering.md
+++ b/.claude/rules/harness-engineering.md
@@ -52,7 +52,7 @@ defect windows = less wasted agent work.
 | `tdd-gate.sh`             | PreToolUse Edit/Write on `*.rs` | Require a test file or tdd skill before production Rust edits. |
 | `procrastination-gate.sh` | PreToolUse Edit/Write | Block "TODO: later" / "後で対応" patterns in new content. |
 | `safety-gate.sh`          | PreToolUse Bash | Block `rm -rf /`, `git push --force`, `git reset --hard`, `--no-verify`, `curl \| sh`, Bash-level config writes. |
-| `commit-gate.sh`          | PreToolUse Bash (`git commit`) | Run fmt-check / clippy / test + require `rust-review-done` + `e2e-done` markers where relevant. |
+| `commit-gate.sh`          | PreToolUse Bash (`git commit`) | Run fmt-check / clippy / test + require `rust-review-done` marker when Rust is staged. |
 | `post-edit-rust.sh`       | PostToolUse Edit/Write | Run `rustfmt --check` on edited Rust files and inject the diff back as `additionalContext`. |
 | `mark-post-tool.sh`       | PostToolUse Read/Skill/Agent/Write/Edit | Update session markers so downstream gates can check state. |
 | `stop-gate.sh`            | Stop | Run `cargo check --all-targets` if Rust was edited; emit `{decision: "block"}` on failure. |
@@ -71,7 +71,6 @@ files; their presence encodes workflow state.
 | `tests-edited`          | Edit/Write on test files | *(audit)* | a test file was edited |
 | `tdd-tests-written`     | rust-testing/tdd skill OR test file edit | tdd-gate | TDD prerequisite satisfied |
 | `rust-review-done`      | Agent(rust-reviewer) / Skill(rust-review) | commit-gate | review completed |
-| `e2e-done`              | Skill(reviewq-e2e) | commit-gate | TUI e2e completed |
 | `tests-just-passed`     | commit-gate after `cargo test` | stop-gate | skip redundant check |
 | `config-edit-approved`  | /config-edit slash command | config-protect-gate | config edits unlocked |
 | `branch-delete-approved:<safe_name>` | /confirm-branch-delete slash command | safety-gate (class 5) | force-delete of that specific branch unlocked once |

--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -60,7 +60,7 @@ This project ships 127+ skills from [Everything Claude Code](https://github.com/
 | Trigger                                                                             | Skill(s)                                                      |
 |-------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | Any new feature or bug fix                                                          | `tdd-workflow`, `rust-testing` (write tests FIRST)            |
-| TUI behavior changes (`src/tui/**`)                                                 | `reviewq-e2e`                                                 |
+| TUI behavior changes (`src/tui/**`)                                                 | Add / update render-layer tests in `tests/tui_render.rs` (TestBackend-based) so `cargo test` covers the change. `reviewq-e2e` is optional for extra interactive verification but no longer required by the commit gate. |
 | Regression risk on existing behavior                                                | `ai-regression-testing`                                       |
 | Coverage check before hand-off                                                      | `test-coverage` command                                       |
 

--- a/tests/tui_render.rs
+++ b/tests/tui_render.rs
@@ -1,0 +1,300 @@
+//! TUI render-layer snapshot tests.
+//!
+//! These tests drive each view's `render` function against a ratatui
+//! `TestBackend` so we can assert the rendered cell buffer without a real
+//! terminal. This is what lets the "TUI e2e" guarantee live inside
+//! `cargo test` instead of depending on a session-scoped skill marker.
+
+use chrono::{DateTime, Utc};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use reviewq::tui::app::{App, View};
+use reviewq::tui::{prompt_view, queue_view, review_view};
+use reviewq::types::{AgentKind, Job, JobStatus, RepoId};
+use std::time::Duration;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn test_terminal(width: u16, height: u16) -> Terminal<TestBackend> {
+    let backend = TestBackend::new(width, height);
+    Terminal::new(backend).expect("TestBackend terminal should construct")
+}
+
+/// Dump a `Buffer` to a single string, one row per line. Styles are stripped —
+/// only the cell symbol is kept — which lets tests use plain substring
+/// assertions against the rendered frame.
+fn buffer_to_string(buf: &Buffer) -> String {
+    let area = buf.area;
+    let mut out = String::with_capacity((area.width as usize + 1) * area.height as usize);
+    for y in area.y..area.y + area.height {
+        for x in area.x..area.x + area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[track_caller]
+fn assert_buffer_contains(term: &Terminal<TestBackend>, needle: &str) {
+    let dump = buffer_to_string(term.backend().buffer());
+    assert!(
+        dump.contains(needle),
+        "buffer did not contain `{needle}`. Full buffer:\n{dump}"
+    );
+}
+
+#[track_caller]
+fn assert_buffer_does_not_contain(term: &Terminal<TestBackend>, needle: &str) {
+    let dump = buffer_to_string(term.backend().buffer());
+    assert!(
+        !dump.contains(needle),
+        "buffer unexpectedly contained `{needle}`. Full buffer:\n{dump}"
+    );
+}
+
+fn fixed_time() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+        .expect("valid rfc3339 literal")
+        .with_timezone(&Utc)
+}
+
+fn make_job(id: i64, status: JobStatus, owner: &str, repo: &str) -> Job {
+    Job {
+        id,
+        repo: RepoId::new(owner, repo),
+        pr_number: (100 + id) as u64,
+        head_sha: format!("deadbeef{id:02}cafebabe"),
+        agent_kind: AgentKind::Claude,
+        status,
+        leased_at: None,
+        lease_expires: None,
+        retry_count: 0,
+        max_retries: 3,
+        command: Some("echo hi".into()),
+        prompt_template: None,
+        pid: None,
+        exit_code: None,
+        stdout_path: None,
+        stderr_path: None,
+        worktree_path: None,
+        review_output: None,
+        session_id: None,
+        cancel_requested_at: None,
+        created_at: fixed_time(),
+        updated_at: fixed_time(),
+    }
+}
+
+fn make_app() -> (App, TempDir) {
+    let tmp = TempDir::new().expect("temp dir");
+    let app = App::new(tmp.path().to_path_buf());
+    (app, tmp)
+}
+
+fn draw_queue(term: &mut Terminal<TestBackend>, app: &mut App) {
+    term.draw(|f| {
+        let area = f.area();
+        queue_view::render(f, app, area);
+    })
+    .expect("draw queue");
+}
+
+fn draw_review(term: &mut Terminal<TestBackend>, app: &mut App) {
+    term.draw(|f| {
+        let area = f.area();
+        review_view::render(f, app, area);
+    })
+    .expect("draw review");
+}
+
+fn draw_prompt(term: &mut Terminal<TestBackend>, app: &mut App) {
+    term.draw(|f| {
+        let area = f.area();
+        prompt_view::render(f, app, area);
+    })
+    .expect("draw prompt");
+}
+
+// ---------------------------------------------------------------------------
+// Queue view
+// ---------------------------------------------------------------------------
+
+#[test]
+fn queue_renders_title_with_zero_jobs_when_empty() {
+    let mut term = test_terminal(100, 24);
+    let (mut app, _tmp) = make_app();
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "reviewq queue");
+    assert_buffer_contains(&term, "0 job(s)");
+}
+
+#[test]
+fn queue_renders_status_summary_counts_by_state() {
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    app.update_jobs(vec![
+        make_job(1, JobStatus::Queued, "owner", "alpha"),
+        make_job(2, JobStatus::Running, "owner", "beta"),
+        make_job(3, JobStatus::Succeeded, "owner", "gamma"),
+        make_job(4, JobStatus::Failed, "owner", "delta"),
+    ]);
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "Queued: 1");
+    assert_buffer_contains(&term, "Running: 1");
+    assert_buffer_contains(&term, "Done: 1");
+    assert_buffer_contains(&term, "Failed: 1");
+}
+
+#[test]
+fn queue_renders_job_rows_with_repo_names() {
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    app.update_jobs(vec![
+        make_job(7, JobStatus::Queued, "octocat", "hello-world"),
+        make_job(8, JobStatus::Running, "rust-lang", "rust"),
+    ]);
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "octocat/hello-world");
+    assert_buffer_contains(&term, "rust-lang/rust");
+}
+
+#[test]
+fn queue_highlights_selected_row_with_arrow_marker() {
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    app.update_jobs(vec![
+        make_job(1, JobStatus::Queued, "o", "r"),
+        make_job(2, JobStatus::Queued, "o", "r"),
+        make_job(3, JobStatus::Queued, "o", "r"),
+    ]);
+    app.selected_index = 1;
+    draw_queue(&mut term, &mut app);
+
+    // The render must propagate selected_index into the persistent
+    // TableState so subsequent mouse / scroll events stay in sync.
+    assert_eq!(app.table_state.selected(), Some(1));
+
+    // The queue layout is: title(y=0) + status(y=1) + header(y=2) +
+    // separator(y=3), so the table body starts at y=4. With three jobs and
+    // no scroll, selected_index=1 must produce the "▸ " highlight marker on
+    // y=5 specifically — not just "somewhere in the buffer", which would
+    // pass even if the wrong row were highlighted.
+    let dump = buffer_to_string(term.backend().buffer());
+    let lines: Vec<&str> = dump.lines().collect();
+    let highlight_row = 5;
+    assert!(
+        lines
+            .get(highlight_row)
+            .is_some_and(|line| line.contains("▸")),
+        "expected highlight marker on row {highlight_row} for selected_index=1. \
+         Full buffer:\n{dump}"
+    );
+    // And the *other* data rows must NOT carry the marker.
+    for y in [4usize, 6] {
+        assert!(
+            lines.get(y).is_some_and(|line| !line.contains("▸")),
+            "row {y} should not be highlighted. Full buffer:\n{dump}"
+        );
+    }
+}
+
+#[test]
+fn queue_render_populates_last_table_area_for_mouse_clicks() {
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    app.update_jobs(vec![make_job(1, JobStatus::Queued, "o", "r")]);
+    assert!(app.last_table_area.is_none());
+
+    draw_queue(&mut term, &mut app);
+
+    let area = app
+        .last_table_area
+        .expect("render must publish last_table_area so mouse clicks map to rows");
+    assert!(area.height > 0);
+    assert!(area.width > 0);
+}
+
+#[test]
+fn queue_renders_flash_status_message() {
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    app.flash("test flash abc123");
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "test flash abc123");
+}
+
+#[test]
+fn queue_does_not_render_flash_after_tick_clears_it() {
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    // ZERO TTL — the flash is set with `expires_at = now()` and is then
+    // tested with `now() >= expires_at` inside `tick_status`. Because
+    // `Instant::now()` is monotonic, the second call is guaranteed to be
+    // `>=` the first, so the flash always expires by the time tick runs.
+    // No sleep is needed and the test cannot flap on a slow host.
+    app.flash_with_ttl("expiring now", Duration::ZERO);
+    app.tick_status();
+    draw_queue(&mut term, &mut app);
+    assert_buffer_does_not_contain(&term, "expiring now");
+}
+
+// ---------------------------------------------------------------------------
+// Review view
+// ---------------------------------------------------------------------------
+
+#[test]
+fn review_view_renders_title_and_body() {
+    let mut term = test_terminal(80, 20);
+    let (mut app, _tmp) = make_app();
+    app.view = View::Review;
+    app.review_text = "Here is the LGTM message".into();
+    draw_review(&mut term, &mut app);
+    assert_buffer_contains(&term, "Review Output");
+    assert_buffer_contains(&term, "LGTM message");
+}
+
+#[test]
+fn review_view_publishes_viewport_height_for_scroll_clamping() {
+    let mut term = test_terminal(80, 20);
+    let (mut app, _tmp) = make_app();
+    app.view = View::Review;
+    app.review_text = "short content".into();
+    assert_eq!(app.content_viewport_height, 0);
+
+    draw_review(&mut term, &mut app);
+
+    // The 80x20 terminal allocates 1 row to the title and 1 row to the help
+    // bar, so the content area must be ~18 rows. A tighter bound than `> 0`
+    // catches layout regressions that would accidentally collapse the
+    // content viewport.
+    assert!(
+        app.content_viewport_height >= 10,
+        "viewport height should be at least 10 rows in an 80x20 terminal, got {}",
+        app.content_viewport_height
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Prompt view
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prompt_view_renders_command_and_prompt_sections() {
+    let mut term = test_terminal(100, 24);
+    let (mut app, _tmp) = make_app();
+    app.view = View::Prompt;
+    app.command_text = "── Command ──\nclaude -p /tmp/out.md\n\n── Prompt ──\nreview please".into();
+    draw_prompt(&mut term, &mut app);
+    // Both structural section headers and the wrapped content lines must
+    // appear, so renaming a section in prompt_view.rs surfaces as a test
+    // failure rather than a silent regression.
+    assert_buffer_contains(&term, "── Command ──");
+    assert_buffer_contains(&term, "claude -p /tmp/out.md");
+    assert_buffer_contains(&term, "── Prompt ──");
+    assert_buffer_contains(&term, "review please");
+}


### PR DESCRIPTION
## Summary

Replaces the trivially-bypassable `e2e-done` session marker with real `cargo test` coverage of the TUI render layer.

### Why

Previously, the commit gate required an `e2e-done` marker before allowing any commit that touched `src/tui/**`. The marker was set the moment the `reviewq-e2e` skill was loaded — it was proof that an agent had *thought about* running e2e, not that any interactive test had actually executed. The previous session caught itself doing exactly this: skill loaded, marker set, commit unblocked, no real e2e ever happened. The gate was a placebo.

### What changed

- **`tests/tui_render.rs` (new)** — 10 tests that drive each TUI view's `render(f, &mut app, area)` against ratatui 0.29's `TestBackend` and assert the rendered cell buffer. Coverage:
  - `queue_view`: empty state, status counts (4 states), repo names, selected-row highlight (with row-position verification), `last_table_area` side-effect, flash message, flash TTL clearing
  - `review_view`: title + body, `content_viewport_height` publish for scroll clamping
  - `prompt_view`: structural section markers (`── Command ──` / `── Prompt ──`) and content
- **Helpers** — `buffer_to_string`, `assert_buffer_contains`, `assert_buffer_does_not_contain`, all with `#[track_caller]` so failures point at the test, not the helper. Mirrors the conventions in `tests/integration.rs`.
- **`commit-gate.sh`** — Section 5 (`e2e-done` check) deleted. Inline comment explains the rationale.
- **`mark-post-tool.sh`** — `Skill(reviewq-e2e)` no longer sets `e2e-done`. Header comment updated.
- **`.claude/rules/harness-engineering.md`** — `e2e-done` row removed from the marker vocabulary table; `commit-gate.sh` row updated.
- **`.claude/rules/skills.md`** — Phase 4 now points TUI changes at `tests/tui_render.rs` as the required gate. `reviewq-e2e` becomes optional for ad-hoc interactive verification.

### Why TestBackend specifically

reviewq's TUI is unusually well-suited to in-process render testing because PR #40 already separated state (`App::dispatch`), key/mouse mapping (`map_key` / `map_mouse`), and view rendering (`queue_view::render` etc.) into pure functions. The render functions only need a `Frame` and `&mut App`, and ratatui ships `TestBackend` for exactly this use case. No new dependencies, no terminal subprocess, no flake risk.

### Trade-offs

- Substring assertions on UI copy ("0 job(s)", "Queued: 1") are coupled to the format strings in `queue_view.rs`. A cosmetic rename will surface as a runtime test failure rather than a compile error. This is normal for string-based UI tests and consistent with the existing `tests/integration.rs` style. If this becomes painful, format prefixes can be promoted to `pub(crate) const` in a follow-up.
- The selected-row highlight test assumes the queue layout is title(y=0) → status(y=1) → header(y=2) → separator(y=3) → table body(y=4+). If the layout changes, the test's hardcoded `highlight_row = 5` needs to move with it. Documented inline.
- The `e2e-done` marker is a hard delete, not a deprecation. It is no longer set anywhere and is no longer referenced anywhere. There is nothing left to remove later.

## Test plan

- [x] `cargo test --test tui_render` — 10 passed in 0.02s
- [x] `make all` — fmt + clippy `-D warnings` + cargo test + 65 hook self-tests, all green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Hook self-tests (`make test-hooks`) — 65/65 passing, no `e2e-done` references in any test
- [x] rust-reviewer agent pass — Warning verdict, two HIGH issues addressed before commit:
  - H1 (TTL=0 race): clarified with comment that `Instant::now()` is monotonic so `>=` always evaluates true on subsequent calls; switched to `Duration::ZERO`
  - H2 (highlight assertion was vacuous): now verifies the marker is on the *correct* row (y=5 for `selected_index=1`) and that adjacent rows are NOT highlighted, plus asserts `app.table_state.selected() == Some(1)`