### PR TITLE
chore(hooks): expire stale session markers and lint on stop

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -77,6 +77,30 @@ cleanup_log=$(reviewq_session_dir)/session-start-cleanup.log
             echo "removed stale fsmonitor ipc socket"
         fi
     fi
+
+    # --- session marker TTL ---
+    # Without this, a long-lived markers directory accumulates state from
+    # weeks-old sessions and downstream gates (skill-invoked, agents-md-read,
+    # rust-files-edited, ...) can spuriously pass because some prior session
+    # touched the marker. The iter3-iter4 transition hit exactly this:
+    # iter4 inherited iter3's `e2e-done` marker and the e2e gate looked
+    # green when it had not actually run.
+    #
+    # Policy: any session marker dir whose mtime is more than 24h old gets
+    # moved (not deleted) to `.archive/`, preserving forensics for review.
+    # The current session is always kept; `.archive/` itself is skipped.
+    session_root="$cwd/.claude/.session"
+    current_sid=$(reviewq_jq '.session_id')
+    if [[ -d "$session_root" ]]; then
+        archive="$session_root/.archive"
+        mkdir -p "$archive"
+        while IFS= read -r stale; do
+            base=$(basename "$stale")
+            [[ "$base" == ".archive" || "$base" == "$current_sid" ]] && continue
+            mv "$stale" "$archive/" 2>/dev/null && \
+                echo "archived stale session dir (>24h): $base"
+        done < <(find "$session_root" -mindepth 1 -maxdepth 1 -type d -mtime +1 2>/dev/null)
+    fi
 } > "$cleanup_log" 2>&1 || true
 
 # --- collect context snippets --------------------------------------------
@@ -112,8 +136,9 @@ msg+=$'- Production *.rs edits are blocked until a test file or\n'
 msg+=$'  tdd-workflow / rust-testing skill has been touched.\n'
 msg+=$'- `git commit` runs fmt-check / clippy -D warnings / cargo test\n'
 msg+=$'  and requires a rust-review-done marker if *.rs is staged.\n'
-msg+=$'- `cargo check` runs on Stop when *.rs files were edited; you\n'
-msg+=$'  cannot end the turn with a broken build.\n'
+msg+=$'- `cargo clippy --all-targets -D warnings` runs on Stop when *.rs\n'
+msg+=$'  files were edited; you cannot end the turn with a broken build\n'
+msg+=$'  or any clippy warning (including doc-comment lints).\n'
 msg+=$'- Destructive bash (rm -rf wildcards, force-push, --no-verify,\n'
 msg+=$'  git reset --hard) is blocked by safety-gate.sh.\n\n'
 

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Stop hook: when the agent signals "done", verify the build actually
-# compiles before letting the turn end. Emits a JSON `{"decision":"block"}`
-# response when the check fails so Claude is forced to keep working.
+# compiles AND passes clippy before letting the turn end. Emits a JSON
+# `{"decision":"block"}` response when the check fails so Claude is
+# forced to keep working.
 #
 # Rationale (from harness-engineering articles):
 #
@@ -14,14 +15,19 @@
 # Policy:
 #   - If no Rust source files were edited this session (no
 #     rust-files-edited marker), exit 0 (nothing to verify).
-#   - Otherwise run `cargo check --quiet` from the session's cwd.
-#     We use `check`, not `test`, because:
-#       * check catches ~95% of "silent done" lies (compile errors,
-#         missing imports, broken signatures),
-#       * test is slow enough that running it on every turn would make
-#         the agent loop sluggish,
-#       * commit-gate.sh already enforces full `cargo test` before a
-#         commit can land, which is the real quality gate.
+#   - Otherwise run `cargo clippy --quiet --all-targets -- -D warnings`
+#     from the session's cwd. We use clippy (not bare `cargo check`)
+#     because:
+#       * clippy is a strict superset of check — it catches every compile
+#         error AND every clippy lint, including doc-comment markdown
+#         violations (`clippy::doc_markdown`) that bare `check` misses,
+#       * the iter3→iter4 transition hit exactly this gap: a `>=` inside
+#         a doc comment escaped Stop and only failed at commit-gate after
+#         several minutes of wasted work,
+#       * benchmarked at ~1.5–2.2s on warm-cache reviewq, which is well
+#         within Stop-hook latency budget,
+#       * `cargo test` is still owned by commit-gate.sh — we don't run
+#         the full suite on every Stop, only the lint-and-typecheck pass.
 #   - On failure, emit `{"decision":"block","reason":...}` JSON so Claude
 #     sees it and keeps working.
 #   - Also honor a `tests-just-passed` marker: if the commit-gate (or a
@@ -73,16 +79,16 @@ if [[ ! -f "$cwd/Cargo.toml" ]]; then
 fi
 
 log_file="$(reviewq_session_dir)/stop-gate-check.log"
-if (cd "$cwd" && cargo check --quiet --all-targets) >"$log_file" 2>&1; then
+if (cd "$cwd" && cargo clippy --quiet --all-targets -- -D warnings) >"$log_file" 2>&1; then
     reviewq_mark tests-just-passed
-    reviewq_log_event allow "Stop: cargo check passed"
+    reviewq_log_event allow "Stop: cargo clippy passed"
     exit 0
 fi
 
 tail_output=$(tail -40 "$log_file")
-reason=$(printf 'Stop blocked: `cargo check` does not compile. You cannot claim "done" while the build is broken.\n\nLast 40 lines:\n%s\n\nFix the compile errors (and their root causes — do not #[allow] them) before ending the turn. The commit-gate will additionally enforce full clippy + test on git commit.' "$tail_output")
+reason=$(printf 'Stop blocked: `cargo clippy --all-targets -- -D warnings` failed. You cannot claim "done" while the build is broken or clippy reports warnings.\n\nLast 40 lines:\n%s\n\nFix the underlying issue (do not `#[allow]` it) before ending the turn. The commit-gate will additionally enforce full `cargo test` on git commit.' "$tail_output")
 
-reviewq_log_event block "Stop: cargo check failed"
+reviewq_log_event block "Stop: cargo clippy failed"
 
 # Emit Stop-hook JSON on stdout so Claude treats this as a block-with-
 # guidance rather than a fatal error.

--- a/.claude/hooks/tests/run-tests.sh
+++ b/.claude/hooks/tests/run-tests.sh
@@ -752,6 +752,25 @@ runcase "allow: Stop with tests-just-passed marker" stop-gate.sh 0 '{
 }'
 cleanup_session "$SID"
 
+# Stop with rust-files-edited marker actually runs `cargo clippy --all-targets
+# -- -D warnings` against the repo. The repo is clippy-clean (otherwise the
+# whole hook test suite would already be failing), so this should pass and
+# also set the tests-just-passed marker as a side effect.
+SID=$(scratch_session); mark_for_session "$SID" rust-files-edited
+runcase "allow: Stop runs clippy on a clean tree" stop-gate.sh 0 '{
+  "session_id":"'"$SID"'",
+  "hook_event_name":"Stop",
+  "cwd":"'"$REPO"'"
+}'
+if [[ -f "$REPO/.claude/.session/$SID/tests-just-passed" ]]; then
+    printf '  \e[32mPASS\e[0m Stop sets tests-just-passed after clippy success\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m Stop did not set tests-just-passed marker\n'
+    FAIL=$((FAIL + 1))
+fi
+cleanup_session "$SID"
+
 echo "== session-start.sh =="
 
 # session-start emits JSON on stdout; just verify exit code and that the
@@ -770,6 +789,52 @@ else
     FAIL=$((FAIL + 1))
 fi
 cleanup_session "$SID"
+
+# session-start should archive marker dirs older than 24h while preserving
+# the current session and any dirs that are still fresh. We seed three
+# scratch dirs:
+#   - one with mtime in the year 2000  → expected: archived
+#   - one with current mtime           → expected: kept in place
+#   - the current session              → expected: kept in place
+STALE_SID="iter5-ttl-stale-$$-$RANDOM"
+FRESH_SID="iter5-ttl-fresh-$$-$RANDOM"
+CURRENT_SID="iter5-ttl-current-$$-$RANDOM"
+mkdir -p "$REPO/.claude/.session/$STALE_SID" \
+         "$REPO/.claude/.session/$FRESH_SID" \
+         "$REPO/.claude/.session/$CURRENT_SID"
+# Year 2000 → unambiguously older than 24h regardless of clock skew.
+touch -t 200001010000 "$REPO/.claude/.session/$STALE_SID"
+# (Fresh and current dirs already have mtime = now from mkdir.)
+
+printf '%s' '{
+  "session_id":"'"$CURRENT_SID"'",
+  "hook_event_name":"SessionStart",
+  "cwd":"'"$REPO"'"
+}' | "$HOOKS/session-start.sh" >/dev/null 2>&1
+
+ttl_ok=1
+if [[ ! -d "$REPO/.claude/.session/.archive/$STALE_SID" ]]; then
+    ttl_ok=0
+    printf '  \e[31mFAIL\e[0m stale session dir was not archived\n'
+fi
+if [[ ! -d "$REPO/.claude/.session/$FRESH_SID" ]]; then
+    ttl_ok=0
+    printf '  \e[31mFAIL\e[0m fresh session dir was incorrectly archived\n'
+fi
+if [[ ! -d "$REPO/.claude/.session/$CURRENT_SID" ]]; then
+    ttl_ok=0
+    printf '  \e[31mFAIL\e[0m current session dir was incorrectly archived\n'
+fi
+if [[ "$ttl_ok" -eq 1 ]]; then
+    printf '  \e[32mPASS\e[0m session marker TTL archives stale dirs only\n'
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+fi
+# Cleanup all three plus the archived stale dir.
+rm -rf "$REPO/.claude/.session/.archive/$STALE_SID" \
+       "$REPO/.claude/.session/$FRESH_SID" \
+       "$REPO/.claude/.session/$CURRENT_SID"
 
 echo "== post-edit-rust.sh =="
 

--- a/.claude/rules/harness-engineering.md
+++ b/.claude/rules/harness-engineering.md
@@ -29,7 +29,7 @@ From nyosegawa's harness-engineering best-practices article:
 ```
   milliseconds   — PostToolUse formatter (post-edit-rust.sh → rustfmt --check)
   seconds        — PreToolUse gates (worktree / agents-md / skill / tdd)
-  seconds        — Stop hook (cargo check --all-targets)
+  ~2 sec         — Stop hook (cargo clippy --all-targets -- -D warnings)
   tens of sec    — commit-gate (cargo fmt --check + clippy + test)
   minutes        — CI (full test matrix, not yet wired)
   hours+         — human review (PR approval, only on risky changes)
@@ -44,7 +44,7 @@ defect windows = less wasted agent work.
 
 | Hook | Event | Purpose |
 |------|-------|---------|
-| `session-start.sh`        | SessionStart | Emit git status / log / worktree list / PROGRESS.md as context so the agent resumes with state. |
+| `session-start.sh`        | SessionStart | Emit git status / log / worktree list / PROGRESS.md as context so the agent resumes with state. Also expires session marker dirs older than 24h to `.claude/.session/.archive/`. |
 | `worktree-gate.sh`        | PreToolUse Edit/Write | Block edits outside `.worktree/` per AGENTS.md. |
 | `agents-md-gate.sh`       | PreToolUse Edit/Write | Require AGENTS.md was Read this session. |
 | `config-protect-gate.sh`  | PreToolUse Edit/Write | Block edits to Cargo.toml / Makefile / CI / linter config unless `/config-edit` unlocks. |
@@ -55,7 +55,7 @@ defect windows = less wasted agent work.
 | `commit-gate.sh`          | PreToolUse Bash (`git commit`) | Run fmt-check / clippy / test + require `rust-review-done` + `e2e-done` markers where relevant. |
 | `post-edit-rust.sh`       | PostToolUse Edit/Write | Run `rustfmt --check` on edited Rust files and inject the diff back as `additionalContext`. |
 | `mark-post-tool.sh`       | PostToolUse Read/Skill/Agent/Write/Edit | Update session markers so downstream gates can check state. |
-| `stop-gate.sh`            | Stop | Run `cargo check --all-targets` if Rust was edited; emit `{decision: "block"}` on failure. |
+| `stop-gate.sh`            | Stop | Run `cargo clippy --all-targets -- -D warnings` if Rust was edited; emit `{decision: "block"}` on failure. Catches both compile errors and clippy lints (e.g. `clippy::doc_markdown`) at turn boundary instead of letting them escape to commit-gate. |
 
 ## Marker vocabulary
 


### PR DESCRIPTION
## Summary

Closes two harness-engineering gaps surfaced by the iter3→iter4 retro:

1. **Stale session markers** — `.claude/.session/<sid>/` dirs were never cleaned up, so a brand-new session inherited markers from a previous one. iter4 hit exactly this: it inherited iter3's `e2e-done` marker and the e2e gate looked green when nothing had actually run this session.
2. **Doc-comment lint trap** — Stop hook ran `cargo check`, which does not run clippy lints. A `>=` inside a doc comment was parsed by clippy as an unbalanced blockquote (`clippy::doc_markdown`) and only failed at commit-gate after several minutes of agent work were already wasted.

Both are fixed in this PR with minimal scope: hook scripts only, no Rust changes, no overlap with PR #41.

## Changes

### `session-start.sh` — TTL on session marker dirs

After the existing fsmonitor / worktree cleanup, walk `.claude/.session/` and **move** any subdirectory whose mtime is more than 24h old into `.claude/.session/.archive/`. The current session and `.archive/` itself are always preserved. Stale dirs are archived rather than deleted so they remain available for forensics. Logged to the per-session `session-start-cleanup.log`.

### `stop-gate.sh` — clippy instead of cargo check

`cargo check --quiet --all-targets` becomes `cargo clippy --quiet --all-targets -- -D warnings`.

Why clippy over check:
- Strict superset — catches every compile error AND every clippy lint, including doc-markdown violations.
- Benchmarked at **1.5–2.2 seconds** on warm-cache reviewq (well within Stop hook latency budget).
- Reuses the existing `tests-just-passed` marker so commit-gate skips the redundant work.
- `cargo test` is still owned by commit-gate.sh — Stop only does the lint-and-typecheck pass.

The block reason text is updated accordingly.

### `harness-engineering.md`

- Feedback loop hierarchy: \`\`\`Stop hook (cargo check)\`\`\` → \`\`\`Stop hook (cargo clippy --all-targets -- -D warnings)\`\`\` with the ~2s benchmark number.
- session-start.sh row: notes the new TTL responsibility.
- stop-gate.sh row: notes that doc-comment lints are now caught at the turn boundary instead of escaping to commit-gate.

### Hook self-tests (+3, total 68 passing)

- \`Stop runs clippy on a clean tree\` — exit 0 against the real repo. Verifies clippy actually runs (not silently skipped) and that the Cargo.toml walk-up logic still works.
- \`Stop sets tests-just-passed after clippy success\` — verifies the side-effect that commit-gate.sh and other downstream gates depend on.
- \`session marker TTL archives stale dirs only\` — seeds a year-2000 stale dir, a fresh dir, and the current session's dir; asserts exactly one is archived and the other two stay in place.

## Why this PR is independent of PR #41

This branch was cut from main before #41 merged. The two PRs touch disjoint files:
- **#41**: \`commit-gate.sh\`, \`mark-post-tool.sh\`, \`tests/tui_render.rs\`, \`rules/skills.md\`
- **iter5**: \`session-start.sh\`, \`stop-gate.sh\`, \`hooks/tests/run-tests.sh\`, \`rules/harness-engineering.md\`

The only overlap is \`harness-engineering.md\`, where #41 removes the \`e2e-done\` marker row and iter5 adds a description column to the \`session-start.sh\` and \`stop-gate.sh\` rows. These are different rows and will merge automatically. **Both PRs can land in either order.**

## Test plan

- [x] \`make test-hooks\` — 68 passed / 0 failed (was 65; +3 new cases)
- [x] \`cargo clippy --all-targets -- -D warnings\` benchmarked at 1.5s warm / 2.2s after touching lib.rs — well within Stop budget
- [x] \`make all\` — green (no Rust changes, but the full pipeline still validates)
- [x] Verified TTL test by hand: stale dir mtime set to year 2000 via \`touch -t 200001010000\`, find -mtime +1 picks it up, the hook archives it
- [x] Verified Stop clippy test runs against the real repo and passes (the repo is clippy-clean per #41's \`make all\`)