### PR TITLE
chore: add /begin entry-point command and vendor grill-me skill

### DIFF
--- a/.claude/commands/begin.md
+++ b/.claude/commands/begin.md
@@ -1,0 +1,245 @@
+---
+description: reviewq task entry point. Drives the full workflow — worktree → AGENTS.md → plan-if-needed → skill → TDD → review → /ship — so the agent never trips a hook by accident. Use this whenever the user requests a code change.
+---
+
+# /begin — reviewq task workflow entry point
+
+Task: $ARGUMENTS
+
+You have been asked to start a reviewq task. Execute the steps below in
+order. The reviewq harness has 12 hooks under `.claude/hooks/` that
+**reactively** block bad actions; this command is the **proactive**
+complement that walks you through the correct sequence up front so you
+do not trip those hooks in the first place.
+
+Do not skip steps. Each one names the marker or gate it satisfies, so
+you can debug missing prerequisites quickly via `/harness-status`.
+
+---
+
+## Step 1 — Grill the user
+
+Invoke `Skill(grill-me)` immediately. Before doing anything else,
+interview the user about the task in `$ARGUMENTS` until you have a
+shared understanding of what they actually want. Ask questions one at
+a time. For each question, propose your recommended answer so the
+user can confirm or redirect with minimal friction.
+
+If a question can be answered by exploring the codebase (Read / Glob /
+Grep), explore the codebase instead of asking. No file edits are made
+in this step — only reads — so you do not yet need to be inside a
+worktree, and the `worktree-gate.sh` hook will not fire.
+
+This step exists because requirements ambiguity is the single biggest
+source of wasted work. The hooks downstream cannot catch a faithfully
+implemented but wrong feature; only this step can. Continue grilling
+until **you can write the plan in Step 4 without guessing**.
+
+When the user signals they are satisfied (explicit "ok" / "go" /
+"進めて" or equivalent), proceed to Step 2.
+
+## Step 2 — Verify your location
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git worktree list
+```
+
+If you are in the **main worktree**, do NOT edit anything yet — the
+`worktree-gate.sh` hook will block any Edit/Write outside `.worktree/`.
+You will create a feature worktree in Step 5. If you are already inside
+a `.worktree/<branch>/` from a previous turn, reuse it instead of
+creating a new one.
+
+## Step 3 — Read AGENTS.md
+
+Use the `Read` tool (not `cat` via Bash) on `AGENTS.md`. This sets the
+`agents-md-read` marker that `agents-md-gate.sh` requires before any
+Edit/Write call. You only have to do this once per session.
+
+## Step 4 — Estimate scope, decide on plan mode
+
+Estimate how many files this task will touch and whether it introduces
+a new architectural pattern.
+
+| Scope                                                            | Required action                                              |
+|------------------------------------------------------------------|--------------------------------------------------------------|
+| 1–2 files, no new pattern, well-understood task                  | Skip plan mode, jump to Step 4                               |
+| ≥3 files OR new architectural pattern OR ambiguous requirements  | **`EnterPlanMode` → draft a plan → `ExitPlanMode` → WAIT for user approval before continuing** |
+
+This is the **plan-first enforcement point**. Without `/begin`,
+`.claude/rules/plan-first.md` is paper-only — no PreToolUse hook can
+observe Plan Mode because `EnterPlanMode` is a Claude Code mode
+transition, not a tool call. The only way to enforce "plan first" is
+to write it into the workflow that the user explicitly invokes, which
+is exactly what this step does.
+
+If plan mode is required, the plan you draft must include:
+
+- Restated requirements in your own words (proves you understood)
+- Concrete file list — every file you expect to touch
+- Verification strategy — "how will we know it works?"
+- Risk and rollback notes if anything is destructive or ambiguous
+
+After `ExitPlanMode`, **wait silently for the user to approve**. Do not
+start editing on a draft plan.
+
+## Step 5 — Create a feature worktree
+
+Pick a Conventional Commits prefix and a slug:
+
+```bash
+git worktree add -b <type>/<slug> .worktree/<type>-<slug>
+```
+
+Prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/`,
+`test/`, `ci/`. Use **absolute paths** inside the worktree for all
+subsequent commands rather than `cd`-ing around — keeps the cwd stable
+and avoids stale worktree issues.
+
+## Step 6 — Invoke a routing skill
+
+Per `.claude/rules/skills.md` Phase 3, every Rust source edit requires
+at least one `Skill()` call first. Pick the most relevant entry from
+the routing table. Sensible defaults:
+
+- `rust-patterns` — general Rust work (always safe)
+- `rust-async-patterns` — touching `tokio`, async fn, channels, spawning tasks
+- `rust-skills:m06-error-handling` — designing or refactoring error types
+- `rust-skills:domain-cli` — touching CLI flag / clap subcommand work
+- `rust-testing` — when this is primarily a test-coverage task
+
+This sets the `skill-invoked` marker that `skill-routing-gate.sh`
+requires before the first `*.rs` Edit. Skip-to-save-tokens is
+explicitly forbidden by `.claude/rules/skills.md`.
+
+## Step 7 — Write a failing test FIRST
+
+Test before implementation. Per `.claude/rules/testing.md` and the
+`tdd-workflow` / `rust-testing` skills, the test must be written before
+any production change. This sets the `tdd-tests-written` /
+`tests-edited` marker that `tdd-gate.sh` checks.
+
+For TUI changes specifically, add a TestBackend-based render test in
+`tests/tui_render.rs` (see PR #41 for the pattern). For hook changes,
+add a case to `.claude/hooks/tests/run-tests.sh` so `make test-hooks`
+covers the new behavior.
+
+## Step 8 — Implement minimally
+
+Make the failing test green with the smallest possible diff. No bonus
+refactors. No "while I'm here" cleanups. No new abstractions for
+hypothetical future requirements. Each unrelated improvement gets its
+own future `/begin` invocation.
+
+## Step 9 — Local verification
+
+```bash
+make all
+```
+
+Must be green: fmt + clippy `-D warnings` + `cargo test` + 68+ hook
+self-tests. The Stop hook will *also* run
+`cargo clippy --all-targets -- -D warnings` automatically when this
+turn ends (per PR #42), so even if you forget to run `make all`, the
+turn cannot end with a broken build or a clippy warning.
+
+## Step 10 — Code review
+
+```
+/rust-review
+```
+
+Or call the agent directly via the `Agent` tool with
+`subagent_type: rust-reviewer`. Address all CRITICAL and HIGH issues.
+This sets the `rust-review-done` marker that `commit-gate.sh` requires
+when any `.rs` file is staged.
+
+## Step 11 — Commit
+
+**ASK THE USER FIRST.** The global `~/.claude/CLAUDE.md` rule is
+absolute: never `git commit` without explicit user approval. Once
+approved:
+
+```bash
+git add <specific files>      # never `git add .` or `-A`
+git commit -m "<type>: <subject>"
+```
+
+Conventional Commits, English only. The `commit-gate.sh` hook will run
+fmt-check + clippy + test + verify the `rust-review-done` marker.
+
+## Step 12 — Ship
+
+```
+/ship
+```
+
+`/ship` is the closing complement to `/begin`. It runs `make all` one
+more time as a last line of defense, pushes the branch with `-u`, and
+drafts the PR title/body from the branch's full commit history. It
+refuses to run from the main worktree, from `main` branch, with a
+dirty tree, with no commits ahead, or with a failing `make all`. See
+`.claude/commands/ship.md` for the full preconditions list.
+
+`/ship` is intentionally NOT a Stop hook — opening a PR is a human
+decision, and the local loop must hand off explicitly to the
+shared-state loop.
+
+## Step 13 — After merge
+
+Once the PR merges, run from inside the worktree:
+
+```
+/cleanup-worktree --restore-cwd --delete-branch
+```
+
+`--restore-cwd` is required by the global `~/.claude/CLAUDE.md` rule
+to keep the session's tools alive after the directory is removed.
+
+---
+
+## Why this command exists
+
+The reviewq harness has two layers:
+
+```
+ユーザー入力
+    ↓
+[/begin <task>]   ← pro-flow (proactively presents the correct sequence)
+    ↓
+agent runs steps 1–13
+    ↓
+[12 hooks]        ← anti-violation (reactively blocks broken actions)
+    ↓
+完成
+```
+
+Until `/begin` existed, the agent only had the reactive layer. Hooks
+caught the agent *after* it tried to do something wrong, which wasted
+turns and produced confusing block messages. `/begin` is the missing
+proactive layer: it tells the agent the entire workflow up front, in
+order, so the hooks rarely have to fire.
+
+The hooks remain in place as a safety net. `/begin` does not bypass
+any of them — every Edit/Write/Bash inside steps 4–11 still passes
+through the normal PreToolUse gates, the Stop hook still runs clippy
+at turn end, and `/ship` still has its own preconditions. Defense in
+depth.
+
+It also makes `.claude/rules/plan-first.md` finally executable. Plan
+Mode is invisible to PreToolUse hooks, so no gate can enforce it
+mechanically. By embedding the plan-first decision into Step 3 of a
+user-invoked command, the rule moves from paper to practice.
+
+## When NOT to use /begin
+
+- **One-off questions** ("what does this function do?") — no edits needed.
+- **Pure observability** (`/harness-status`, `git log`, reading files).
+- **Continuing an already-started task** in the same worktree — re-enter
+  the worktree directly, the markers from the previous turn are still
+  in place. Skipping `/begin` here is fine because steps 1–5 are
+  already satisfied.
+
+For any task that produces a PR, **always** start with `/begin`.

--- a/.claude/hooks/tests/run-tests.sh
+++ b/.claude/hooks/tests/run-tests.sh
@@ -857,6 +857,66 @@ fi
 rm -f "$scratch_rs"
 cleanup_session "$SID"
 
+echo "== /begin command (entry-point smoke) =="
+
+# /begin is the proactive entry point — see .claude/commands/begin.md
+# and .claude/rules/harness-engineering.md "Two layers" section. We do
+# not exercise the slash command end-to-end (slash commands are
+# Claude-side, not bash-side), but we do guard the contract that the
+# command file exists and references the steps that the rest of the
+# harness depends on.
+BEGIN_MD="$REPO/.claude/commands/begin.md"
+if [[ -f "$BEGIN_MD" ]]; then
+    printf '  \e[32mPASS\e[0m .claude/commands/begin.md exists\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m .claude/commands/begin.md is missing\n'
+    FAIL=$((FAIL + 1))
+fi
+
+# Required phrases that downstream rules / docs link against. If any of
+# these get renamed in begin.md without updating the rules files, the
+# pro-flow / anti-violation contract is broken.
+required_in_begin=(
+    "Skill(grill-me)"
+    "EnterPlanMode"
+    "ExitPlanMode"
+    "AGENTS.md"
+    "worktree"
+    "rust-review"
+    "/ship"
+    "make all"
+    "Step 4"
+)
+begin_ok=1
+if [[ -f "$BEGIN_MD" ]]; then
+    for needle in "${required_in_begin[@]}"; do
+        if ! grep -qF "$needle" "$BEGIN_MD"; then
+            begin_ok=0
+            printf '  \e[31mFAIL\e[0m begin.md missing required phrase: %s\n' "$needle"
+        fi
+    done
+fi
+if [[ "$begin_ok" -eq 1 && -f "$BEGIN_MD" ]]; then
+    printf '  \e[32mPASS\e[0m begin.md contains all required phrases\n'
+    PASS=$((PASS + 1))
+else
+    [[ -f "$BEGIN_MD" ]] && FAIL=$((FAIL + 1))
+fi
+
+# /begin Step 1 invokes Skill(grill-me), so the project-local copy of
+# the grill-me skill must exist. The skill is intentionally duplicated
+# from the global ~/.claude/skills/ so the project's `/begin` flow does
+# not depend on per-machine global state.
+GRILL_MD="$REPO/.claude/skills/grill-me/SKILL.md"
+if [[ -f "$GRILL_MD" ]]; then
+    printf '  \e[32mPASS\e[0m .claude/skills/grill-me/SKILL.md exists (project-local copy)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  \e[31mFAIL\e[0m grill-me skill is not vendored under .claude/skills/\n'
+    FAIL=$((FAIL + 1))
+fi
+
 echo
 echo "== Summary =="
 printf "  passed: %d\n  failed: %d\n" "$PASS" "$FAIL"

--- a/.claude/rules/harness-engineering.md
+++ b/.claude/rules/harness-engineering.md
@@ -40,6 +40,64 @@ into commit-gate. Whenever it exists at commit-gate, ask whether it can
 migrate into the Stop or PostToolUse layer. Faster feedback = smaller
 defect windows = less wasted agent work.
 
+## Two layers: pro-flow and anti-violation
+
+The harness has two distinct enforcement layers that compose:
+
+```
+ユーザー入力
+    ↓
+[/begin <task>]    ← pro-flow      (proactively presents the correct
+    ↓                                workflow before any action)
+agent runs steps 1-13
+    ↓
+[12 hooks]         ← anti-violation (reactively blocks broken actions
+    ↓                                when the agent slips)
+[/ship]            ← exit gate     (push + PR with full preconditions)
+    ↓
+完成
+```
+
+### Anti-violation (the 12 hooks)
+
+The Hook index below catalogs the reactive layer. Each hook fires on a
+specific tool event and blocks the agent if a precondition is missing.
+This layer is **necessary but not sufficient**: it tells the agent
+*after the fact* that something is wrong, which wastes turns and
+produces fragmented error messages spread across the session.
+
+### Pro-flow (the `/begin` command)
+
+`/begin <task>` (`.claude/commands/begin.md`) is the user-invoked
+entry point that hands the agent the entire workflow up front, in
+order, before any action is taken. Steps 1–13 cover: **`Skill(grill-me)`
+to interview the user until requirements are clear** → location check →
+AGENTS.md read → **plan-mode decision** → worktree creation → skill
+routing → write tests first → implement → `make all` → `/rust-review`
+→ commit (with user approval) → `/ship` → cleanup after merge.
+
+`/begin` does **not** bypass any hook. Every Edit/Write/Bash inside
+its steps still passes through the normal PreToolUse gates, the Stop
+hook still runs clippy at turn end, and `/ship` still has its own
+preconditions. The two layers are defense in depth, not alternatives.
+
+### Why both are needed
+
+- Pro-flow alone is **best-effort**: the agent might forget a step
+  mid-task. The hooks catch the slip.
+- Anti-violation alone is **reactive**: the agent has to *try* to do
+  something wrong before being stopped. Pro-flow primes the correct
+  sequence so hooks rarely have to fire.
+- Plan-first specifically **cannot** live in the hook layer because
+  Plan Mode is invisible to PreToolUse hooks. It only lives in
+  `/begin` Step 3. See `.claude/rules/plan-first.md` for the
+  reasoning.
+
+When the user requests a code change, they should start with `/begin
+<task>`. When the agent inevitably slips (forgets to read AGENTS.md,
+edits before invoking a skill, tries to commit without rust-review),
+the hooks catch it.
+
 ## Hook index
 
 | Hook | Event | Purpose |

--- a/.claude/rules/plan-first.md
+++ b/.claude/rules/plan-first.md
@@ -17,6 +17,25 @@ skip the plan mode step and execute directly — but **still inside a
 fresh worktree** per `.claude/rules/git-workflow.md`. The worktree
 requirement has no size exemption.
 
+## How this rule is enforced
+
+This rule **cannot** be enforced by a PreToolUse hook: `EnterPlanMode`
+is a Claude Code mode transition, not a tool call, so no gate can
+observe whether the agent entered it. Instead, the rule is operationalized
+through the `/begin <task>` slash command (see
+`.claude/commands/begin.md`).
+
+`/begin` Step 3 explicitly asks the agent to estimate scope and
+**requires** plan mode for any task touching ≥3 files or introducing a
+new pattern. The agent must `EnterPlanMode`, draft a plan covering all
+four points above, call `ExitPlanMode`, and **wait for user approval**
+before any Edit/Write happens. Steps 4 onward (worktree creation,
+implementation, review, ship) only run after the user approves.
+
+When you ask the agent to do work, prefer starting with `/begin <task
+description>`. Without that command, this rule degrades to a guideline
+that the agent may forget — the hook layer cannot catch the violation.
+
 ## Why
 
 `plan-and-handoff` / `blueprint` skills exist for this. Without a plan

--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -17,8 +17,11 @@ This project ships 127+ skills from [Everything Claude Code](https://github.com/
 
 **Mandatory for every task**, no exemptions for "tiny" changes. reviewq requires a dedicated git worktree per feature branch (see `AGENTS.md` → Git Workflow).
 
+The recommended entry point is the **`/begin <task>`** slash command (see `.claude/commands/begin.md`), which walks the agent through Phases 0–6 in order — including the plan-first check that no PreToolUse hook can enforce. The table below covers the same ground, but `/begin` is the proactive form and should be preferred whenever the user is requesting a code change.
+
 | Trigger                                                                             | Skill(s) / Action                                             |
 |-------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| User requests a code change of any size                                             | Prefer `/begin <task>` — it drives every step in this file in order. |
 | First filesystem edit of a task, any size                                           | Verify `git worktree list` + `git rev-parse --show-toplevel`; if in the main worktree, run `git worktree add -b <type>/<slug> .worktree/<type>-<slug>` and `cd` into it before editing. |
 | User asks for a "quick fix" / "one-liner" / "just commit this"                      | Still create a worktree first. There is **no** small-change exemption. |
 | Found yourself editing on `main` by mistake                                         | `git stash push -u`, create the worktree, `git -C .worktree/<name> stash pop`, continue there. |

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## Summary

Adds the **proactive (pro-flow)** layer that complements the 12 reactive
hooks. Until now the harness only had anti-violation enforcement: the
agent had to *try* to do something wrong before the hooks blocked it,
which wasted turns and produced fragmented error messages. `/begin <task>`
is the missing user-invoked entry point that hands the agent the entire
workflow up front, in order, before any action is taken.

This also makes `.claude/rules/plan-first.md` finally executable. Plan
Mode is invisible to PreToolUse hooks (it is a Claude Code mode
transition, not a tool call), so no gate could enforce it. By embedding
the plan-first decision into Step 4 of a user-invoked command, the rule
moves from paper to practice.

## What changed

### `/begin` (`.claude/commands/begin.md`, new)

A 13-step workflow:

1. **`Skill(grill-me)`** — interview the user until requirements are clear
2. Verify location (worktree / branch)
3. Read `AGENTS.md` (sets `agents-md-read` marker)
4. **Estimate scope, decide on plan mode** (the only place plan-first can be enforced)
5. Create feature worktree
6. Invoke routing skill (sets `skill-invoked` marker)
7. Write failing test FIRST (sets `tdd-tests-written` marker)
8. Implement minimally
9. `make all`
10. `/rust-review` (sets `rust-review-done` marker)
11. Commit (after explicit user approval)
12. `/ship` (preconditions + push + draft PR)
13. Cleanup after merge

The command does **not** bypass any hook. Every Edit/Write/Bash inside its
steps still passes through the existing PreToolUse gates, the Stop hook
still runs clippy at turn end, and `/ship` still has its own
preconditions. Defense in depth.

### `grill-me` skill, vendored (not moved)

Step 1 calls `Skill(grill-me)`, so the project needs a local copy of the
skill rather than depending on per-machine global state under
`~/.claude/skills/`. The 10-line `SKILL.md` is duplicated verbatim from
the global skill — the global copy is intentionally left in place so
other projects keep working.

### `plan-first.md`

New \"How this rule is enforced\" section explaining that the rule cannot
live in a PreToolUse hook (Plan Mode is invisible to hooks) and now lives
operationally in `/begin` Step 4.

### `harness-engineering.md`

New \"Two layers: pro-flow and anti-violation\" section after the
feedback-loop hierarchy. Documents the split between `/begin` (proactive
workflow priming) and the 12 hooks (reactive blocking), and explains why
plan-first specifically can only live in the pro-flow layer.

### `skills.md`

Phase 0 now lists `/begin <task>` as the recommended entry point with a
one-line trigger row, so the routing table itself points at the new
command for any code-change request.

### Hook self-tests (+3, total 71 passing)

- \`.claude/commands/begin.md exists\` (smoke)
- \`begin.md contains all required phrases\` (contract)
- \`.claude/skills/grill-me/SKILL.md exists (project-local copy)\` (smoke)

The \"required phrases\" check guards \`Skill(grill-me)\`, \`EnterPlanMode\`,
\`ExitPlanMode\`, \`AGENTS.md\`, \`worktree\`, \`rust-review\`, \`/ship\`, \`make all\`,
and \`Step 4\`. If any of those get renamed in \`begin.md\` without updating
the rule files, the hook test fails — the pro-flow / anti-violation
contract cannot silently rot.

## Why Step 1 is grill-me

Requirements ambiguity is the single biggest source of wasted work in
agent-driven development. The hooks downstream cannot catch a faithfully
implemented but **wrong** feature. Only an explicit interview step can.
Step 1 forces the agent to grill the user until \"you can write the plan
in Step 4 without guessing\", which short-circuits the most expensive
class of failure (work that compiles, passes tests, ships, and then has
to be ripped out because it solved the wrong problem).

## Test plan

- [x] \`make all\` — green (no Rust changes; full pipeline still validates)
- [x] \`make test-hooks\` — 71 passed / 0 failed (was 68; +3 new cases)
- [x] All required-phrase guards pass against the actual \`begin.md\`
- [x] grill-me skill exists at the project-local path
- [x] Verified that \`begin.md\` references \`/ship\` (added by PR #43)