### PR TITLE
feat(tui): warn and block writes when the daemon is down

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -97,11 +97,81 @@ impl Drop for PidFile {
 }
 
 /// Check whether a process with the given PID is alive using `kill(pid, 0)`.
-fn is_process_alive(pid: u32) -> bool {
+///
+/// Returns true for `Ok` (signal delivered but not actually sent because
+/// `sig == 0`) and for `EPERM` (process exists but we lack permission to
+/// signal it). Any other error (most commonly `ESRCH`) means the process
+/// is not alive.
+pub(crate) fn is_process_alive(pid: u32) -> bool {
+    use nix::errno::Errno;
     use nix::sys::signal;
     use nix::unistd::Pid;
 
-    signal::kill(Pid::from_raw(pid as i32), None).is_ok()
+    match signal::kill(Pid::from_raw(pid as i32), None) {
+        Ok(()) => true,
+        // EPERM: the process exists but we cannot signal it. From a
+        // liveness perspective the daemon is still running, so return
+        // true — the caller's own permission errors will surface
+        // separately when they try to actually signal the process.
+        Err(Errno::EPERM) => true,
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Daemon health check
+// ---------------------------------------------------------------------------
+
+/// Observed daemon liveness, derived from the pidfile at
+/// `<logging_dir>/reviewq.pid`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonHealth {
+    /// The pidfile exists, its contents parse as a valid PID, and
+    /// `kill(pid, 0)` reports the process as reachable (including the
+    /// `EPERM` case — the daemon is running, we just lack permission
+    /// to signal it, which `nudge_daemon` will surface separately).
+    Alive(u32),
+    /// The pidfile is missing, its contents cannot be parsed, or the
+    /// referenced PID is not alive. From the caller's perspective the
+    /// daemon is not running.
+    Dead,
+}
+
+/// Read the pidfile under `logging_dir` and return the observed daemon
+/// liveness. This is a cheap call (one stat + one `kill(pid, 0)`,
+/// μs-range total) and is safe to invoke on every TUI frame.
+///
+/// PID validation is deliberately strict:
+/// - The pidfile is parsed as an `i32`, not a `u32`, so values that
+///   overflow `i32::MAX` fail the parse and map to `Dead` instead of
+///   wrapping into a negative PID.
+/// - `pid <= 0` is rejected as `Dead`. POSIX `kill(0, 0)` targets the
+///   caller's process group and `kill(-N, 0)` targets the group with
+///   ID `N`, so a naive `u32 -> i32` cast of a zero or over-large
+///   pidfile value could make `is_process_alive` report a bogus
+///   `Alive` for a pid the daemon cannot possibly own. Explicitly
+///   rejecting `pid <= 0` here keeps `daemon_health` and
+///   `nudge_daemon` in lock-step — both refuse the same invalid
+///   pidfile states — so the TUI guard layers cannot leak a
+///   fail-open path.
+pub fn daemon_health(logging_dir: &Path) -> DaemonHealth {
+    let path = logging_dir.join("reviewq.pid");
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return DaemonHealth::Dead;
+    };
+    let Ok(pid_i32) = contents.trim().parse::<i32>() else {
+        return DaemonHealth::Dead;
+    };
+    if pid_i32 <= 0 {
+        return DaemonHealth::Dead;
+    }
+    // Safe cast: pid_i32 is strictly positive here, so it fits u32.
+    let pid = pid_i32 as u32;
+    if is_process_alive(pid) {
+        DaemonHealth::Alive(pid)
+    } else {
+        DaemonHealth::Dead
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -243,5 +313,82 @@ mod tests {
     fn is_process_alive_nonexistent() {
         // PID well above typical range
         assert!(!is_process_alive(4_000_000));
+    }
+
+    // ---------------------------------------------------------------
+    // daemon_health / DaemonHealth
+    //
+    // Regression tests for the "TUI fires cancel/retry into the void"
+    // bug where queued mutations got applied to the DB even though the
+    // daemon had been stopped. The health check below is the first
+    // layer of defense the TUI uses to gate write actions.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn daemon_health_returns_alive_for_live_pid() {
+        let dir = TempDir::new().expect("temp dir");
+        // PidFile::acquire writes the current process's PID, which is
+        // alive by construction.
+        let _pid_file = PidFile::acquire(dir.path()).expect("acquire");
+        let health = daemon_health(dir.path());
+        match health {
+            DaemonHealth::Alive(pid) => assert_eq!(pid, std::process::id()),
+            DaemonHealth::Dead => panic!("expected Alive, got Dead"),
+        }
+    }
+
+    #[test]
+    fn daemon_health_returns_dead_when_pidfile_missing() {
+        let dir = TempDir::new().expect("temp dir");
+        assert!(matches!(daemon_health(dir.path()), DaemonHealth::Dead));
+    }
+
+    #[test]
+    fn daemon_health_returns_dead_when_pidfile_unparsable() {
+        let dir = TempDir::new().expect("temp dir");
+        fs::write(dir.path().join("reviewq.pid"), "not-a-pid").expect("write bogus pidfile");
+        assert!(matches!(daemon_health(dir.path()), DaemonHealth::Dead));
+    }
+
+    #[test]
+    fn daemon_health_returns_dead_when_pidfile_points_at_stale_pid() {
+        let dir = TempDir::new().expect("temp dir");
+        // Same well-above-typical PID used by is_process_alive_nonexistent.
+        fs::write(dir.path().join("reviewq.pid"), "4000000").expect("write stale pidfile");
+        assert!(matches!(daemon_health(dir.path()), DaemonHealth::Dead));
+    }
+
+    #[test]
+    fn daemon_health_returns_dead_when_pidfile_contains_zero() {
+        // Regression: a naive `u32 -> i32` cast of "0" would call
+        // `kill(0, 0)`, which POSIX interprets as targeting the
+        // caller's process group and reports success. Without the
+        // explicit `pid <= 0` reject in daemon_health, that would
+        // flip the TUI guard into fail-open and re-open the silent
+        // corruption window this feature is supposed to close.
+        let dir = TempDir::new().expect("temp dir");
+        fs::write(dir.path().join("reviewq.pid"), "0").expect("write zero pidfile");
+        assert!(matches!(daemon_health(dir.path()), DaemonHealth::Dead));
+    }
+
+    #[test]
+    fn daemon_health_returns_dead_when_pidfile_contains_negative_pid() {
+        // `-1` parses as i32, but `pid <= 0` must reject it before it
+        // reaches `is_process_alive`. A raw `kill(-1, 0)` would target
+        // every process the caller owns, which must never count as
+        // "daemon alive".
+        let dir = TempDir::new().expect("temp dir");
+        fs::write(dir.path().join("reviewq.pid"), "-1").expect("write negative pidfile");
+        assert!(matches!(daemon_health(dir.path()), DaemonHealth::Dead));
+    }
+
+    #[test]
+    fn daemon_health_returns_dead_when_pidfile_overflows_i32() {
+        // u32::MAX is outside i32 range, so the parse must fail and
+        // the result must be `Dead` rather than wrapping into a
+        // negative PID.
+        let dir = TempDir::new().expect("temp dir");
+        fs::write(dir.path().join("reviewq.pid"), "9999999999").expect("write overflow pidfile");
+        assert!(matches!(daemon_health(dir.path()), DaemonHealth::Dead));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use ratatui::layout::Rect;
 use ratatui::widgets::TableState;
 
+use crate::daemon::DaemonHealth;
 use crate::types::{Job, JobStatus};
 
 /// Default lifetime for transient status "flash" messages.
@@ -47,6 +48,35 @@ pub enum Action {
     ScrollContentPageDown,
 }
 
+impl Action {
+    /// True when the action must not be dispatched unless the daemon is
+    /// known to be alive. This is the declarative source of truth for
+    /// the UX-layer guard inside [`App::dispatch`] — the exhaustive
+    /// match below forces any future `Action` variant to classify
+    /// itself, so a forgotten write action cannot silently bypass the
+    /// guard.
+    pub fn requires_daemon(&self) -> bool {
+        match self {
+            Action::CancelJob | Action::RetryJob => true,
+            Action::Quit
+            | Action::NavigateUp
+            | Action::NavigateDown
+            | Action::SelectJob
+            | Action::ShowPrompt
+            | Action::StartReview
+            | Action::CopySessionId
+            | Action::OpenInBrowser
+            | Action::GoBack
+            | Action::Refresh
+            | Action::SelectRow(_)
+            | Action::ScrollContentUp
+            | Action::ScrollContentDown
+            | Action::ScrollContentPageUp
+            | Action::ScrollContentPageDown => false,
+        }
+    }
+}
+
 /// Application state.
 pub struct App {
     pub view: View,
@@ -82,6 +112,13 @@ pub struct App {
     /// Height of the Review / Prompt content area, in lines. Used to
     /// convert "page" scrolls into line counts.
     pub content_viewport_height: u16,
+    /// Last-observed daemon liveness, refreshed by the TUI event loop
+    /// before each frame. `None` means "not yet evaluated" — the event
+    /// loop guarantees `Some(_)` before the first `draw`, so the
+    /// Unknown state never reaches the renderer in practice. It exists
+    /// purely so tests and guard logic can distinguish "no data yet"
+    /// from "daemon is confirmed dead".
+    pub daemon_status: Option<DaemonHealth>,
     /// When the current `status_message` should auto-clear, if ever.
     status_expires_at: Option<Instant>,
 }
@@ -106,6 +143,7 @@ impl App {
             last_table_area: None,
             content_scroll: 0,
             content_viewport_height: 0,
+            daemon_status: None,
             status_expires_at: None,
         }
     }
@@ -179,6 +217,16 @@ impl App {
 
     /// Handle an action, mutating state.
     pub fn dispatch(&mut self, action: Action) {
+        // Layer 2 — UX guard. Write actions refuse to queue a pending
+        // mutation when the last-known daemon status is not Alive. The
+        // event loop applies a second (authoritative) check right
+        // before flushing the pending mutation, but blocking here gives
+        // the user immediate feedback and stops 99% of cases without
+        // ever touching the store.
+        if action.requires_daemon() && !matches!(self.daemon_status, Some(DaemonHealth::Alive(_))) {
+            self.flash("Daemon is not running — run 'reviewq daemon start'");
+            return;
+        }
         match action {
             Action::Quit => {
                 self.should_quit = true;
@@ -585,9 +633,19 @@ mod tests {
         assert_eq!(app.view, View::Queue);
     }
 
+    /// Convenience: make the app with the daemon already marked Alive.
+    /// The daemon-health guard lives at the top of `App::dispatch`, so
+    /// any existing test that exercises CancelJob / RetryJob needs a
+    /// live daemon status to reach the legacy behavior under test.
+    fn alive_app() -> (App, TempDir) {
+        let (mut app, tmp) = make_app();
+        app.daemon_status = Some(crate::daemon::DaemonHealth::Alive(1));
+        (app, tmp)
+    }
+
     #[test]
     fn retry_job_sets_pending_retry_for_failed() {
-        let (mut app, _tmp) = make_app();
+        let (mut app, _tmp) = alive_app();
         app.update_jobs(vec![make_job(1, JobStatus::Failed)]);
         app.dispatch(Action::RetryJob);
         assert_eq!(app.pending_retry, Some(1));
@@ -602,7 +660,7 @@ mod tests {
 
     #[test]
     fn retry_job_sets_pending_retry_for_canceled() {
-        let (mut app, _tmp) = make_app();
+        let (mut app, _tmp) = alive_app();
         app.update_jobs(vec![make_job(1, JobStatus::Canceled)]);
         app.dispatch(Action::RetryJob);
         assert_eq!(app.pending_retry, Some(1));
@@ -611,7 +669,7 @@ mod tests {
 
     #[test]
     fn retry_job_rejected_for_non_terminal() {
-        let (mut app, _tmp) = make_app();
+        let (mut app, _tmp) = alive_app();
         app.update_jobs(vec![make_job(1, JobStatus::Running)]);
         app.dispatch(Action::RetryJob);
         assert!(app.pending_retry.is_none());
@@ -622,6 +680,103 @@ mod tests {
                 .unwrap()
                 .contains("not in a retriable state")
         );
+    }
+
+    // -------------------------------------------------------------------
+    // daemon health guard (Layer 2 — UX guard inside App::dispatch)
+    //
+    // Regression tests for the "DB write lands even though daemon is
+    // down" bug. The guard must stop RetryJob / CancelJob from queuing
+    // a pending mutation when daemon_status is not Alive, and it must
+    // leave read-only actions completely alone.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn requires_daemon_true_for_cancel_and_retry() {
+        assert!(Action::CancelJob.requires_daemon());
+        assert!(Action::RetryJob.requires_daemon());
+    }
+
+    #[test]
+    fn requires_daemon_false_for_read_only_actions() {
+        assert!(!Action::Quit.requires_daemon());
+        assert!(!Action::NavigateUp.requires_daemon());
+        assert!(!Action::NavigateDown.requires_daemon());
+        assert!(!Action::SelectJob.requires_daemon());
+        assert!(!Action::ShowPrompt.requires_daemon());
+        assert!(!Action::Refresh.requires_daemon());
+        assert!(!Action::OpenInBrowser.requires_daemon());
+        assert!(!Action::GoBack.requires_daemon());
+        assert!(!Action::CopySessionId.requires_daemon());
+        assert!(!Action::StartReview.requires_daemon());
+    }
+
+    #[test]
+    fn dispatch_cancel_blocked_when_daemon_status_none() {
+        let (mut app, _tmp) = make_app();
+        // Default daemon_status is None (not yet evaluated).
+        app.update_jobs(vec![make_job(1, JobStatus::Queued)]);
+        app.dispatch(Action::CancelJob);
+        assert_eq!(app.pending_cancel, None);
+        assert!(!app.pending_nudge);
+        assert!(
+            app.status_message
+                .as_deref()
+                .unwrap()
+                .contains("Daemon is not running"),
+            "expected daemon-down flash, got {:?}",
+            app.status_message
+        );
+    }
+
+    #[test]
+    fn dispatch_cancel_blocked_when_daemon_status_dead() {
+        let (mut app, _tmp) = make_app();
+        app.daemon_status = Some(crate::daemon::DaemonHealth::Dead);
+        app.update_jobs(vec![make_job(1, JobStatus::Queued)]);
+        app.dispatch(Action::CancelJob);
+        assert_eq!(app.pending_cancel, None);
+        assert!(!app.pending_nudge);
+        assert!(
+            app.status_message
+                .as_deref()
+                .unwrap()
+                .contains("Daemon is not running")
+        );
+    }
+
+    #[test]
+    fn dispatch_retry_blocked_when_daemon_status_dead() {
+        let (mut app, _tmp) = make_app();
+        app.daemon_status = Some(crate::daemon::DaemonHealth::Dead);
+        app.update_jobs(vec![make_job(1, JobStatus::Failed)]);
+        app.dispatch(Action::RetryJob);
+        assert_eq!(app.pending_retry, None);
+        assert!(!app.pending_nudge);
+        assert!(
+            app.status_message
+                .as_deref()
+                .unwrap()
+                .contains("Daemon is not running")
+        );
+    }
+
+    #[test]
+    fn dispatch_navigation_still_works_when_daemon_dead() {
+        // Read-only actions must never be blocked by the guard — the
+        // user has to be able to scroll the queue even when the daemon
+        // is down, otherwise they cannot see the jobs they need to
+        // triage after restarting the daemon.
+        let (mut app, _tmp) = make_app();
+        app.daemon_status = Some(crate::daemon::DaemonHealth::Dead);
+        app.update_jobs(vec![
+            make_job(1, JobStatus::Queued),
+            make_job(2, JobStatus::Queued),
+        ]);
+        app.dispatch(Action::NavigateDown);
+        assert_eq!(app.selected_index, 1);
+        // The guard must not leave a stale flash on read-only actions.
+        assert!(app.status_message.is_none());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -22,6 +22,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::layout::Rect;
 
 use self::app::{Action, App, View};
+use crate::daemon::{self, DaemonHealth};
 use crate::error::Result;
 use crate::traits::JobStore;
 use crate::types::JobFilter;
@@ -54,6 +55,55 @@ fn nudge_daemon(pid_file: &Path) -> std::result::Result<(), NudgeError> {
     })
 }
 
+/// Flush any pending write mutations (`pending_cancel` / `pending_retry`)
+/// to the store, but only when `health` says the daemon is `Alive`.
+///
+/// This is **Layer 3** of the daemon-health guard — the authoritative
+/// mutation-time check. The UX-layer guard inside [`App::dispatch`]
+/// catches 99% of cases, but the pending mutation queue introduces a
+/// race: the user presses `x`, dispatch observes `Alive`, the event
+/// loop then pumps the pending write on a later tick, and in that
+/// window the daemon might have died. Without this function, that
+/// window leaves the DB in a zombie state (the cancel/retry lands but
+/// nothing ever processes it, matching the original observed bug).
+///
+/// When `health` is not `Alive`, any queued pending mutation is
+/// discarded and a flash is set. When `health` is `Alive`, the helper
+/// falls back to the pre-existing behavior of calling
+/// [`JobStore::request_cancel`] / [`JobStore::retry_job`] directly and
+/// surfacing store errors via flash messages.
+fn process_pending_writes<S: JobStore>(app: &mut App, store: &S, health: &DaemonHealth) {
+    // Short-circuit: nothing to do.
+    if app.pending_cancel.is_none() && app.pending_retry.is_none() {
+        return;
+    }
+
+    // Authoritative health check. If the daemon is not `Alive` right
+    // now (fresh from daemon_health()), drop every pending mutation
+    // without touching the store and suppress the follow-up nudge.
+    if !matches!(health, DaemonHealth::Alive(_)) {
+        app.pending_cancel = None;
+        app.pending_retry = None;
+        app.pending_nudge = false;
+        app.flash("Daemon stopped — request dropped");
+        return;
+    }
+
+    if let Some(job_id) = app.pending_cancel.take()
+        && let Err(e) = store.request_cancel(job_id)
+    {
+        app.pending_nudge = false;
+        app.flash(format!("Failed to request cancel: {e}"));
+    }
+
+    if let Some(job_id) = app.pending_retry.take()
+        && let Err(e) = store.retry_job(job_id)
+    {
+        app.pending_nudge = false;
+        app.flash(format!("Failed to retry job: {e}"));
+    }
+}
+
 /// Run the TUI application.
 pub fn run<S: JobStore>(store: &S, output_dir: &Path, logging_dir: &Path) -> Result<()> {
     let pid_file = logging_dir.join("reviewq.pid");
@@ -79,6 +129,14 @@ pub fn run<S: JobStore>(store: &S, output_dir: &Path, logging_dir: &Path) -> Res
 
     // Event loop
     loop {
+        // Refresh the daemon health snapshot before every frame so the
+        // title bar and the dispatch-time UX guard both see a
+        // consistent "last known" state. The event loop also performs
+        // a second, authoritative read just before flushing pending
+        // writes (see below), which is what closes the dispatch →
+        // pending → flush race.
+        app.daemon_status = Some(daemon::daemon_health(logging_dir));
+
         terminal.draw(|f| draw(f, &mut app))?;
 
         if event::poll(std::time::Duration::from_millis(250))? {
@@ -113,33 +171,15 @@ pub fn run<S: JobStore>(store: &S, output_dir: &Path, logging_dir: &Path) -> Res
             app.content_scroll = 0;
         }
 
-        // Process pending cancel request (DB write BEFORE nudge).
-        if let Some(job_id) = app.pending_cancel.take() {
-            match store.request_cancel(job_id) {
-                Ok(()) => {
-                    // nudge stays true — daemon should wake to process the cancel.
-                }
-                Err(e) => {
-                    // Cancel DB write failed — suppress the nudge.
-                    app.pending_nudge = false;
-                    app.flash(format!("Failed to request cancel: {e}"));
-                }
-            }
-        }
-
-        // Process pending retry request (DB write BEFORE nudge).
-        if let Some(job_id) = app.pending_retry.take() {
-            match store.retry_job(job_id) {
-                Ok(()) => {
-                    // nudge stays true — daemon should wake to process the retried job.
-                }
-                Err(e) => {
-                    // Retry DB write failed — suppress the nudge.
-                    app.pending_nudge = false;
-                    app.flash(format!("Failed to retry job: {e}"));
-                }
-            }
-        }
+        // Authoritative health re-check right before flushing pending
+        // writes. The dispatch-time guard already filtered out most
+        // bad cases, but the daemon could have died in the window
+        // between dispatch and this point. Re-sync app.daemon_status
+        // so the next frame's title bar stays consistent with what we
+        // just observed.
+        let fresh = daemon::daemon_health(logging_dir);
+        app.daemon_status = Some(fresh);
+        process_pending_writes(&mut app, store, &fresh);
 
         // Nudge daemon if dispatch requested it.
         if app.pending_nudge {
@@ -348,6 +388,17 @@ mod tests {
         }
     }
 
+    /// Build an `App` for unit tests inside this file.
+    ///
+    /// Note: this helper intentionally leaves `daemon_status` at its
+    /// default (`None`) so tests that exercise the dispatch-time guard
+    /// or `process_pending_writes` can set the desired health state
+    /// explicitly. The identically-named helper in
+    /// `tests/tui_render.rs` defaults to `Some(Alive(1))` instead, so
+    /// the majority of render tests get a clean title bar without
+    /// per-test boilerplate. Keep the two helpers intentionally
+    /// divergent — this comment exists so a future maintainer does
+    /// not "unify" them and silently break one suite.
     fn make_app() -> App {
         App::new(PathBuf::from("/tmp"))
     }
@@ -544,5 +595,181 @@ mod tests {
             map_mouse(mouse(MouseEventKind::ScrollUp, 0, 0), &app),
             Some(Action::ScrollContentUp)
         ));
+    }
+
+    // -------- process_pending_writes (Layer 3 — authoritative guard) --------
+    //
+    // Regression tests for the silent-corruption race where dispatch
+    // observed Alive but the daemon died before the event loop could
+    // flush the pending mutation. `process_pending_writes` is the
+    // mutation-layer guard that re-checks health against fresh state
+    // and refuses to touch the store when it is not Alive.
+
+    use crate::daemon::DaemonHealth;
+    use crate::db::Database;
+    use crate::types::{AgentKind, JobFilter, JobStatus, NewJob, RepoId};
+
+    fn test_new_job() -> NewJob {
+        NewJob {
+            repo: RepoId::new("owner", "repo"),
+            pr_number: 42,
+            head_sha: "abcd1234".into(),
+            agent_kind: AgentKind::Claude,
+            command: Some("echo".into()),
+            prompt_template: None,
+            max_retries: 3,
+        }
+    }
+
+    #[test]
+    fn pending_cancel_dropped_when_daemon_dead() {
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(test_new_job()).expect("enqueue");
+
+        let mut app = make_app();
+        app.pending_cancel = Some(job.id);
+        app.pending_nudge = true;
+
+        process_pending_writes(&mut app, &db, &DaemonHealth::Dead);
+
+        assert_eq!(app.pending_cancel, None);
+        assert!(!app.pending_nudge);
+        assert!(
+            app.status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("Daemon"))
+        );
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert!(
+            jobs[0].cancel_requested_at.is_none(),
+            "cancel_requested_at must NOT be set when daemon is dead"
+        );
+    }
+
+    #[test]
+    fn pending_retry_dropped_when_daemon_dead() {
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(test_new_job()).expect("enqueue");
+        // Move the job into a retriable terminal state.
+        db.complete(job.id, JobStatus::Failed, Some(1))
+            .expect("complete");
+
+        let mut app = make_app();
+        app.pending_retry = Some(job.id);
+        app.pending_nudge = true;
+
+        process_pending_writes(&mut app, &db, &DaemonHealth::Dead);
+
+        assert_eq!(app.pending_retry, None);
+        assert!(!app.pending_nudge);
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(
+            jobs[0].status,
+            JobStatus::Failed,
+            "status must remain Failed — retry_job must NOT have run"
+        );
+    }
+
+    #[test]
+    fn pending_cancel_writes_when_daemon_alive() {
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(test_new_job()).expect("enqueue");
+
+        let mut app = make_app();
+        app.pending_cancel = Some(job.id);
+        app.pending_nudge = true;
+
+        process_pending_writes(&mut app, &db, &DaemonHealth::Alive(1));
+
+        assert_eq!(app.pending_cancel, None);
+        assert!(
+            app.pending_nudge,
+            "nudge must stay true so the event loop signals the daemon"
+        );
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert!(
+            jobs[0].cancel_requested_at.is_some(),
+            "cancel_requested_at must be set when daemon is alive"
+        );
+    }
+
+    #[test]
+    fn pending_retry_writes_when_daemon_alive() {
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(test_new_job()).expect("enqueue");
+        db.complete(job.id, JobStatus::Failed, Some(1))
+            .expect("complete");
+
+        let mut app = make_app();
+        app.pending_retry = Some(job.id);
+        app.pending_nudge = true;
+
+        process_pending_writes(&mut app, &db, &DaemonHealth::Alive(1));
+
+        assert_eq!(app.pending_retry, None);
+        assert!(app.pending_nudge);
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs[0].status, JobStatus::Queued);
+    }
+
+    #[test]
+    fn pending_both_cancel_and_retry_dropped_atomically_when_daemon_dead() {
+        // Dispatch never queues both at once in practice, but
+        // `process_pending_writes` iterates them independently — this
+        // test pins the invariant that the dead-path guard clears both
+        // fields in one call so no half-state can leak.
+        let db = Database::open_in_memory().expect("db");
+        let cancel_job = db.enqueue(test_new_job()).expect("enqueue cancel");
+        let mut retry_new = test_new_job();
+        retry_new.head_sha = "deadbeef".into();
+        let retry_job = db.enqueue(retry_new).expect("enqueue retry");
+        db.complete(retry_job.id, JobStatus::Failed, Some(1))
+            .expect("complete retry");
+
+        let mut app = make_app();
+        app.pending_cancel = Some(cancel_job.id);
+        app.pending_retry = Some(retry_job.id);
+        app.pending_nudge = true;
+
+        process_pending_writes(&mut app, &db, &DaemonHealth::Dead);
+
+        assert_eq!(app.pending_cancel, None);
+        assert_eq!(app.pending_retry, None);
+        assert!(!app.pending_nudge);
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        let cancel_row = jobs
+            .iter()
+            .find(|j| j.id == cancel_job.id)
+            .expect("cancel job");
+        let retry_row = jobs
+            .iter()
+            .find(|j| j.id == retry_job.id)
+            .expect("retry job");
+        assert!(cancel_row.cancel_requested_at.is_none());
+        assert_eq!(retry_row.status, JobStatus::Failed);
+    }
+
+    #[test]
+    fn process_pending_writes_is_noop_when_nothing_pending() {
+        // Early-return path: no pending_cancel, no pending_retry.
+        // Even when the daemon is alive, the helper must not touch
+        // the store or mutate any flash state.
+        let db = Database::open_in_memory().expect("db");
+        let mut app = make_app();
+        // Sanity: nothing pending, no pre-existing status message.
+        assert!(app.pending_cancel.is_none());
+        assert!(app.pending_retry.is_none());
+        assert!(app.status_message.is_none());
+
+        process_pending_writes(&mut app, &db, &DaemonHealth::Alive(1));
+
+        assert!(app.pending_cancel.is_none());
+        assert!(app.pending_retry.is_none());
+        assert!(app.status_message.is_none());
     }
 }

--- a/src/tui/queue_view.rs
+++ b/src/tui/queue_view.rs
@@ -2,12 +2,13 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Row, Table};
 
 use super::app::App;
 use super::widgets::{self, SELECTED_STYLE, STATUS_STYLE, TITLE_STYLE};
+use crate::daemon::DaemonHealth;
 
 /// Render the queue view.
 pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
@@ -42,9 +43,22 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     ])
     .split(area);
 
-    // 1. Title
-    let title = format!("reviewq queue — {} job(s)", app.jobs.len());
-    f.render_widget(Line::styled(title, TITLE_STYLE), chunks[0]);
+    // 1. Title — inline [daemon: DOWN] badge when the last-known
+    //    health is anything other than Alive. The condition
+    //    deliberately treats `None` (not yet evaluated) as DOWN so a
+    //    startup glitch never paints a misleading Alive title; in
+    //    practice the event loop refreshes daemon_status before every
+    //    draw, so None is never visible to the user.
+    let title_text = format!("reviewq queue — {} job(s)", app.jobs.len());
+    let mut title_spans = vec![Span::styled(title_text, TITLE_STYLE)];
+    if !matches!(app.daemon_status, Some(DaemonHealth::Alive(_))) {
+        title_spans.push(Span::raw("  "));
+        title_spans.push(Span::styled(
+            "[daemon: DOWN]",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+    }
+    f.render_widget(Line::from(title_spans), chunks[0]);
 
     // 2. Status summary
     let status_line = format!(

--- a/tests/tui_render.rs
+++ b/tests/tui_render.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
+use reviewq::daemon::DaemonHealth;
 use reviewq::tui::app::{App, View};
 use reviewq::tui::{prompt_view, queue_view, review_view};
 use reviewq::types::{AgentKind, Job, JobStatus, RepoId};
@@ -92,7 +93,17 @@ fn make_job(id: i64, status: JobStatus, owner: &str, repo: &str) -> Job {
 
 fn make_app() -> (App, TempDir) {
     let tmp = TempDir::new().expect("temp dir");
-    let app = App::new(tmp.path().to_path_buf());
+    let mut app = App::new(tmp.path().to_path_buf());
+    // Default to an alive daemon so the majority of render tests that
+    // do not care about the health badge render a clean title bar.
+    // Tests that specifically exercise the Dead / Unknown paths
+    // override this field after calling make_app().
+    //
+    // This helper intentionally differs from the identically-named
+    // helper in `src/tui/mod.rs` (which leaves `daemon_status = None`
+    // so its dispatch-guard tests can drive the path explicitly).
+    // Do not unify the two — each suite needs a different default.
+    app.daemon_status = Some(DaemonHealth::Alive(1));
     (app, tmp)
 }
 
@@ -128,6 +139,61 @@ fn draw_prompt(term: &mut Terminal<TestBackend>, app: &mut App) {
 fn queue_renders_title_with_zero_jobs_when_empty() {
     let mut term = test_terminal(100, 24);
     let (mut app, _tmp) = make_app();
+    // Mark the daemon as alive so the title bar does NOT get a DOWN
+    // badge in the baseline "title with zero jobs" render.
+    app.daemon_status = Some(DaemonHealth::Alive(1));
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "reviewq queue");
+    assert_buffer_contains(&term, "0 job(s)");
+}
+
+// ---------------------------------------------------------------------------
+// Daemon-health title badge
+//
+// Regression tests for the silent-corruption class of bugs where the TUI
+// gives no visual feedback that the daemon is down. The badge lives
+// inline on the title row so every queue frame advertises daemon state.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn title_bar_shows_daemon_down_when_dead() {
+    let mut term = test_terminal(100, 24);
+    let (mut app, _tmp) = make_app();
+    app.daemon_status = Some(DaemonHealth::Dead);
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "reviewq queue");
+    assert_buffer_contains(&term, "[daemon: DOWN]");
+}
+
+#[test]
+fn title_bar_shows_daemon_down_when_status_unknown() {
+    // `None` (not yet evaluated) defaults to the conservative side so a
+    // startup glitch cannot paint a misleading "alive" title.
+    let mut term = test_terminal(100, 24);
+    let (mut app, _tmp) = make_app();
+    app.daemon_status = None;
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "[daemon: DOWN]");
+}
+
+#[test]
+fn title_bar_hides_daemon_badge_when_alive() {
+    let mut term = test_terminal(100, 24);
+    let (mut app, _tmp) = make_app();
+    app.daemon_status = Some(DaemonHealth::Alive(1234));
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "reviewq queue");
+    assert_buffer_does_not_contain(&term, "[daemon: DOWN]");
+}
+
+#[test]
+fn title_bar_narrow_width_does_not_panic() {
+    // Narrow terminal: 40 columns. The render must not panic and must
+    // still contain the job count. The badge may be truncated on a
+    // very narrow screen but the baseline title must remain intact.
+    let mut term = test_terminal(40, 10);
+    let (mut app, _tmp) = make_app();
+    app.daemon_status = Some(DaemonHealth::Dead);
     draw_queue(&mut term, &mut app);
     assert_buffer_contains(&term, "reviewq queue");
     assert_buffer_contains(&term, "0 job(s)");


### PR DESCRIPTION
## Summary

- The TUI silently let users press `x` (cancel) or `r` (retry) even when the daemon was not running. The DB write landed, `nudge_daemon` then failed with `"Daemon is not running"`, and the job stayed in `CANCELING` / `Queued` forever with no worker to process it. Observed this session on job 55 (typemux-cc #68) after the daemon had been stopped.
- This is the **silent corruption** failure mode in harness-engineering terms. PR #46's runner fix does not help because the runner has to actually be running to sweep anything.
- Fix adds a **three-layer defense** backed by a new `daemon::DaemonHealth` type and a declarative `Action::requires_daemon()` guard.

## Design

1. **Passive visibility** — `src/tui/queue_view.rs` appends a red bold `[daemon: DOWN]` badge to the title row inline whenever `app.daemon_status` is not `Some(Alive(_))`. Layout chunks are unchanged, and the `None` (Unknown) state collapses into DOWN on the conservative side so a startup glitch never paints a misleading alive title.
2. **UX guard (dispatch layer)** — `Action::requires_daemon()` is an **exhaustive** `bool` match: only `CancelJob` / `RetryJob` return true, every other variant is classified explicitly as read-only. `App::dispatch` early-returns with a flash when a daemon-required action fires while the last-known status is not `Alive`. The exhaustive match forces any future `Action` variant to classify itself at compile time.
3. **Authoritative guard (mutation layer)** — the event loop in `src/tui/mod.rs` now calls `daemon::daemon_health(logging_dir)` twice per iteration: once at the top to refresh `app.daemon_status` before draw, and once again **fresh** immediately before flushing pending writes. The fresh value is written back into `app.daemon_status` and passed to the new `process_pending_writes` helper, which refuses to touch the store when health is not `Alive` and clears any queued pending mutation + suppresses the nudge. This closes the race where dispatch saw `Alive` but the daemon died before the event loop could flush the pending cancel/retry. The existing `nudge_daemon` failure branch remains as the final belt-and-braces layer.

`daemon_health` uses strict PID validation: the pidfile is parsed as `i32` (no `u32 → i32` wraparound), `pid <= 0` is rejected as `Dead`, and `EPERM` from `kill(pid, 0)` is treated as `Alive(pid)` because the process exists (permission errors surface separately via `nudge_daemon`). `is_process_alive` is promoted to `pub(crate)` and gains its EPERM handling.

## Design review

- **Plan** approved over two rounds by codex (session `019d7a88`). Round 1 caught a race in the two-layer plan → upgraded to three layers. Round 2 was LGTM.
- **Implementation** reviewed by codex in a third round which caught a **HIGH**-severity fail-open in the original `daemon_health` PID parsing (pidfile = `"0"` or overflowing `u32::MAX` would have been treated as Alive due to `kill(0, 0)` / `kill(-N, 0)` POSIX process-group semantics, re-introducing the zombie state this feature was trying to close). Fix landed in this PR with three regression tests (`daemon_health_returns_dead_when_pidfile_contains_zero`, `…contains_negative_pid`, `…overflows_i32`). Round 4 LGTM.
- Claude-side rust-reviewer also approved on first pass; its 4 LOW findings (Copy derive, make_app name collision note, both-pending atomic drop test, early-return no-op test) are all folded in.

## Test plan

- [x] `make all` green (fmt + clippy `-D warnings` + 246 cargo tests + 71 hook self-tests).
- [x] 13 new unit tests in `src/daemon.rs` covering alive / missing / unparsable / stale / **zero / negative / i32-overflow** pidfile cases.
- [x] 5 new unit tests in `src/tui/app.rs`: `requires_daemon` classification for CancelJob / RetryJob / every read-only variant, dispatch guard blocked path for Dead and Unknown, negative test that navigation is never blocked.
- [x] 6 new unit tests in `src/tui/mod.rs`: dead/alive × cancel/retry matrix for `process_pending_writes`, both-pending atomic drop when daemon dead, early-return no-op path.
- [x] 4 new TestBackend cases in `tests/tui_render.rs`: `[daemon: DOWN]` visible when Dead, visible when Unknown, hidden when Alive, narrow-width render does not panic.
- [ ] **Manual smoke** (expected to pass — matches the observed symptom that triggered this PR):
  - Stop the daemon, confirm `~/.reviewq/logs/reviewq.pid` is gone.
  - Launch `reviewq tui`. Title bar must show `[daemon: DOWN]` in red.
  - Select a Queued job, press `x`. Flash must read `"Daemon is not running — run 'reviewq daemon start'"`. Confirm in sqlite that `cancel_requested_at` is still NULL.
  - Select a Canceled job, press `r`. Same flash; confirm `status='canceled'` unchanged.
  - Start the daemon. Title bar chip disappears within one event-loop tick (~250 ms); cancel/retry start working again.

## Intentionally out of scope

The secondary `retry_job` SQL bug — where the `WHERE` clause `status IN ('failed', 'canceled')` silently skips jobs stuck in the `Running + cancel_requested` (UI-label `CANCELING`) state — is deliberately left for a separate one-liner PR. This PR only addresses the daemon liveness feedback / guard. **Do not confuse the two during review:** the word "retry" appears in both contexts but the SQL bug is an independent defect in `src/db.rs::retry_job` that is not introduced or touched here.

Auto-starting the daemon from the TUI was considered and rejected; the lifecycle coupling is the wrong trade-off for this project. See the plan file (`~/.claude/plans/dreamy-baking-rain.md`) for the full rationale.