### PR TITLE
refactor(config): split config.yml into daemon + repos sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,109 +94,100 @@ reviewq tui
 
 Config file location: `--config` flag > `~/.reviewq/config.yml` (default).
 
+The config is split into two top-level sections:
+
+- `daemon:` — resources that exist once per reviewq installation
+  (state DB, poll loop, auth credential, worktree root, global semaphore,
+  log / output directories). There is no per-repo equivalent.
+- `repos:` — repository-level policy. `repos.defaults` acts as a template
+  for every entry in `repos.allowlist`; individual entries can override
+  any field. Fields that neither `defaults` nor the entry sets fall back
+  to a built-in constant.
+
 Below is a complete reference with all options and their defaults.
 
 ```yaml
 # ──────────────────────────────────────────────
-# repos — Repository allowlist (REQUIRED)
+# daemon — One-per-install resources & daemon behavior
+# ──────────────────────────────────────────────
+daemon:
+  polling:
+    interval_seconds: 300                  # Seconds between detection cycles (default: 300)
+
+  auth:
+    method: gh                             # "gh" uses `gh auth token` (default: "gh")
+    fallback_env: GITHUB_TOKEN             # Env var fallback if gh CLI fails (default: "GITHUB_TOKEN")
+
+  execution:
+    worktree_root: ~/.reviewq/worktrees    # Directory for git worktrees (default: ~/.reviewq/worktrees)
+    max_concurrency: 10                    # Global semaphore: max concurrent review jobs (default: 10)
+    lease_minutes: 5                       # Job lease timeout in minutes (default: 5)
+
+  cancel:
+    sigint_timeout_seconds: 5              # SIGINT grace period (default: 5)
+    sigterm_timeout_seconds: 15            # SIGTERM grace period (default: 15)
+    sigkill_timeout_seconds: 5             # SIGKILL wait after SIGTERM (default: 5)
+
+  cleanup:
+    ttl_minutes: 1440                      # Worktree retention period in minutes (default: 1440 = 24h)
+    interval_minutes: 30                   # Cleanup check interval in minutes (default: 30)
+
+  logging:
+    dir: ~/.reviewq/logs                   # Log directory (default: ~/.reviewq/logs)
+
+  state:
+    sqlite_path: ~/.reviewq/state.db       # SQLite database path (default: ~/.reviewq/state.db)
+
+  output:
+    dir: ~/.reviewq/output                 # Review output directory (default: ~/.reviewq/output)
+
+# ──────────────────────────────────────────────
+# repos — Repository allowlist and policy (REQUIRED)
 # ──────────────────────────────────────────────
 repos:
+  # Optional: defaults for every entry in `allowlist`. Each field here
+  # inherits into allowlist entries that don't set the same field. Anything
+  # neither `defaults` nor the entry sets falls back to the built-in value.
+  defaults:
+    skip_self_authored: true               # Skip PRs you authored (built-in: true)
+    skip_reviewer_check: false             # Process all open PRs regardless of reviewer (built-in: false)
+    review_on_push: true                   # Re-review on every push/force-push (built-in: true)
+    agent: claude                          # Agent: claude | codex (built-in: claude)
+    prompt_template: "Review {pr_url}"     # Prompt template (built-in: structured default)
+    model: claude-sonnet-4-5-20250514      # Model passed via --model (built-in: none)
+    base_repo_path: ~/src                  # Base path for local clones (built-in: none)
+    ignore_prs: []                         # PR numbers to exclude (built-in: [])
+
   allowlist:
-    - repo: owner/repo-name               # "owner/name" format (REQUIRED)
-      skip_self_authored: true             # Skip PRs you authored (default: true)
-      skip_reviewer_check: false           # Process all open PRs regardless of reviewer assignment (default: false)
-      review_on_push: true                 # Re-review on every push/force-push (default: true)
-      agent: claude                        # Per-repo agent override: claude | codex (optional)
-      prompt_template: "Review this PR"    # Per-repo prompt template override (optional)
-      model: claude-sonnet-4-5-20250514    # Per-repo model override (optional)
-      max_concurrency: 3                   # Per-repo concurrency limit (optional, reserved for future use)
-      base_repo_path: /path/to/local/clone # Per-repo local clone path (optional)
-      ignore_prs: [100, 200]               # PR numbers to exclude from review (default: [])
-
-# ──────────────────────────────────────────────
-# polling — GitHub API polling interval
-# ──────────────────────────────────────────────
-polling:
-  interval_seconds: 300                    # Seconds between detection cycles (default: 300)
-
-# ──────────────────────────────────────────────
-# auth — GitHub authentication
-# ──────────────────────────────────────────────
-auth:
-  method: gh                               # "gh" uses `gh auth token` (default: "gh")
-  fallback_env: GITHUB_TOKEN               # Env var fallback if gh CLI fails (default: "GITHUB_TOKEN")
-
-# ──────────────────────────────────────────────
-# execution — Job execution settings
-# ──────────────────────────────────────────────
-execution:
-  base_repo_path: /path/to/repos           # Global base path for local clones (optional)
-  worktree_root: /path/to/worktrees        # Directory for git worktrees (optional, default: ~/.reviewq/worktrees)
-  max_concurrency: 10                      # Max concurrent review jobs (default: 10)
-  lease_minutes: 5                         # Job lease timeout in minutes (default: 5)
-
-# ──────────────────────────────────────────────
-# runner — AI review agent settings
-# ──────────────────────────────────────────────
-runner:
-  agent: claude                            # Default agent: claude | codex (default: claude)
-  prompt_template: "Review {pr_url}"       # Global prompt template (optional)
-  model: claude-sonnet-4-5-20250514        # Model passed via --model flag (optional)
-
-# ──────────────────────────────────────────────
-# cancel — Process cancellation timeouts
-# ──────────────────────────────────────────────
-cancel:
-  sigint_timeout_seconds: 5                # SIGINT grace period (default: 5)
-  sigterm_timeout_seconds: 15              # SIGTERM grace period (default: 15)
-  sigkill_timeout_seconds: 5              # SIGKILL wait after SIGTERM (default: 5)
-
-# ──────────────────────────────────────────────
-# cleanup — Worktree cleanup settings
-# ──────────────────────────────────────────────
-cleanup:
-  ttl_minutes: 1440                        # Worktree retention period in minutes (default: 1440 = 24h)
-  interval_minutes: 30                     # Cleanup check interval in minutes (default: 30)
-
-# ──────────────────────────────────────────────
-# logging — Log file settings
-# ──────────────────────────────────────────────
-logging:
-  dir: ~/.reviewq/logs                     # Log directory (default: ~/.reviewq/logs)
-
-# ──────────────────────────────────────────────
-# state — Persistent state database
-# ──────────────────────────────────────────────
-state:
-  sqlite_path: ~/.reviewq/state.db         # SQLite database path (default: ~/.reviewq/state.db)
-
-# ──────────────────────────────────────────────
-# output — Review output files
-# ──────────────────────────────────────────────
-output:
-  dir: ~/.reviewq/output                   # Review output directory (default: ~/.reviewq/output)
+    - repo: owner/repo-name                # "owner/name" format (REQUIRED)
+      # Any of the fields from `defaults` can be overridden here.
+      agent: codex
+      model: gpt-5.3-codex
+      base_repo_path: /custom/path
+      ignore_prs: [100, 200]
 ```
 
 ### Config sections in detail
 
 #### `repos.allowlist` (required)
 
-At least one repository must be listed. Each entry supports these per-repo overrides:
+At least one repository must be listed. Each entry supports the same
+fields as `repos.defaults`; anything not set here inherits from
+`defaults`, and anything neither sets falls back to the built-in value.
 
-| Field                | Type       | Default | Description |
-|----------------------|------------|---------|-------------|
-| `repo`               | `string`   | &mdash; | Repository in `"owner/name"` format (**required**) |
-| `skip_self_authored`  | `bool`     | `true`  | Skip PRs authored by the authenticated user |
-| `skip_reviewer_check` | `bool`    | `false` | Process all open PRs, not just those with review requested |
-| `review_on_push`      | `bool`    | `true`  | Re-review when a new commit is pushed to the PR |
-| `agent`              | `string`   | &mdash; | Override agent: `claude` or `codex` |
-| `prompt_template`    | `string`   | &mdash; | Override prompt template |
-| `model`              | `string`   | &mdash; | Override model name |
-| `max_concurrency`    | `integer`  | &mdash; | Per-repo concurrency limit (reserved for future use) |
-| `base_repo_path`     | `path`     | &mdash; | Path to local clone of this repo |
-| `ignore_prs`         | `[integer]`| `[]`    | PR numbers to exclude from review |
+| Field                 | Type        | Built-in | Description |
+|-----------------------|-------------|----------|-------------|
+| `repo`                | `string`    | &mdash;  | Repository in `"owner/name"` format (**required**) |
+| `skip_self_authored`  | `bool`      | `true`   | Skip PRs authored by the authenticated user |
+| `skip_reviewer_check` | `bool`      | `false`  | Process all open PRs, not just those with review requested |
+| `review_on_push`      | `bool`      | `true`   | Re-review when a new commit is pushed to the PR |
+| `agent`               | `string`    | `claude` | Agent: `claude` or `codex` |
+| `prompt_template`     | `string`    | built-in | Prompt template (see below) |
+| `model`               | `string`    | none     | Model name for the `--model` flag |
+| `base_repo_path`      | `path`      | none     | Path to local clone of this repo |
+| `ignore_prs`          | `[integer]` | `[]`     | PR numbers to exclude from review |
 
-#### `runner.agent`
+#### `repos.defaults.agent`
 
 Selects the AI review agent. Each agent has a built-in default command:
 
@@ -205,30 +196,30 @@ Selects the AI review agent. Each agent has a built-in default command:
 | `claude` | `claude -p "$(cat "{prompt_file}")" --output-format json --allowedTools Read Grep Glob Bash WebFetch WebSearch Agent Skill` |
 | `codex`  | `codex exec --json --sandbox danger-full-access - < "{prompt_file}"` |
 
-**Priority chain**: per-repo `agent` > global `runner.agent` > `claude` (default).
+**Resolution chain**: `RepoEntry.agent` > `repos.defaults.agent` > built-in `claude`.
 
-#### `runner.model`
+#### `repos.defaults.model`
 
 Specifies the model to pass via the `--model` CLI flag.
 
-**Priority chain**: per-repo `model` > global `runner.model` > omitted (no `--model` flag).
+**Resolution chain**: `RepoEntry.model` > `repos.defaults.model` > omitted (no `--model` flag).
 
 Model names must match `[A-Za-z0-9._:-]+`.
 
 ```yaml
-runner:
-  agent: claude
-  model: claude-sonnet-4-5-20250514    # Default model for all repos
-
 repos:
+  defaults:
+    agent: claude
+    model: claude-sonnet-4-5-20250514    # Inherited by every entry below
+
   allowlist:
-    - repo: org/repo-a                 # Uses claude-sonnet-4-5-20250514
-    - repo: org/repo-b
+    - repo: org/repo-a                   # Uses claude-sonnet-4-5-20250514
+    - repo: org/repo-b                   # Overrides both
       agent: codex
-      model: gpt-5.3-codex             # Override: uses gpt-5.3-codex with codex
+      model: gpt-5.3-codex
 ```
 
-#### `runner.prompt_template`
+#### `repos.defaults.prompt_template`
 
 Custom prompt body appended after the built-in PR info header. Supports template variables:
 
@@ -244,7 +235,7 @@ Custom prompt body appended after the built-in PR info header. Supports template
 
 When no `prompt_template` is set, a built-in default prompt is used that produces structured review output with severity levels.
 
-**Priority chain**: per-repo `prompt_template` > global `runner.prompt_template` > built-in default.
+**Resolution chain**: `RepoEntry.prompt_template` > `repos.defaults.prompt_template` > built-in default.
 
 #### `review_on_push`
 
@@ -309,18 +300,18 @@ kill -HUP $(cat ~/.reviewq/logs/reviewq.pid)
 
 Changes to the following fields take effect immediately:
 - `repos.allowlist` (repos, per-repo settings)
-- `polling.interval_seconds`
-- `runner.prompt_template`, `runner.model`
-- `cleanup` settings
-- `output.dir`
+- `repos.defaults` (prompt_template, model, base_repo_path, etc.)
+- `daemon.polling.interval_seconds`
+- `daemon.cleanup` settings
+- `daemon.output.dir`
 
 Changes to these fields require a restart:
-- `auth`
-- `execution.max_concurrency`
-- `runner.agent`
-- `cancel`
-- `logging`
-- `state`
+- `daemon.auth`
+- `daemon.execution.max_concurrency`
+- `daemon.execution.lease_minutes`
+- `daemon.cancel`
+- `daemon.logging`
+- `daemon.state`
 
 ## Architecture
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,40 @@
 //! YAML configuration parsing, validation, and defaults.
+//!
+//! The config is split into two concerns:
+//!
+//! - [`DaemonConfig`] — resources that exist once per reviewq installation
+//!   (state DB, poll loop, auth credential, worktree root, global semaphore,
+//!   logging directory, output directory). These are *not* overridable per
+//!   repo because the daemon only has one of each.
+//! - [`ReposConfig`] — repository-level policy. Fields set on `repos.defaults`
+//!   act as a template for every entry in `repos.allowlist`; individual
+//!   entries can override any field. Fields that neither `defaults` nor the
+//!   entry sets fall back to a built-in constant.
+//!
+//! Example `config.yml`:
+//!
+//! ```yaml
+//! daemon:
+//!   polling:
+//!     interval_seconds: 300
+//!   auth:
+//!     method: gh
+//!     fallback_env: GITHUB_TOKEN
+//!   execution:
+//!     worktree_root: ~/.reviewq/worktrees
+//!     max_concurrency: 10
+//!     lease_minutes: 5
+//!
+//! repos:
+//!   defaults:
+//!     agent: codex
+//!     base_repo_path: ~/src
+//!   allowlist:
+//!     - repo: org/repo-a
+//!     - repo: org/repo-b
+//!       agent: claude
+//!       model: claude-sonnet-4-6
+//! ```
 
 use std::path::{Path, PathBuf};
 
@@ -6,13 +42,38 @@ use serde::Deserialize;
 
 use crate::error::{Result, ReviewqError};
 
-/// Top-level configuration for reviewq.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+// ---------------------------------------------------------------------------
+// Built-in defaults (absolute fallbacks when neither the entry nor
+// `repos.defaults` sets a value).
+// ---------------------------------------------------------------------------
+
+const BUILTIN_SKIP_SELF_AUTHORED: bool = true;
+const BUILTIN_SKIP_REVIEWER_CHECK: bool = false;
+const BUILTIN_REVIEW_ON_PUSH: bool = true;
+
+// ---------------------------------------------------------------------------
+// Top-level
+// ---------------------------------------------------------------------------
+
+/// Top-level reviewq configuration.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
-    pub repos: ReposConfig,
+    pub daemon: DaemonConfig,
 
+    #[serde(default)]
+    pub repos: ReposConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Daemon-scoped configuration
+// ---------------------------------------------------------------------------
+
+/// Daemon-wide settings. One-per-install resources.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DaemonConfig {
     #[serde(default)]
     pub polling: PollingConfig,
 
@@ -21,9 +82,6 @@ pub struct Config {
 
     #[serde(default)]
     pub execution: ExecutionConfig,
-
-    #[serde(default)]
-    pub runner: RunnerConfig,
 
     #[serde(default)]
     pub cancel: CancelConfig,
@@ -39,101 +97,6 @@ pub struct Config {
 
     #[serde(default)]
     pub output: OutputConfig,
-}
-
-// ---------------------------------------------------------------------------
-// Sub-configs
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReposConfig {
-    #[serde(default)]
-    pub allowlist: Vec<RepoEntry>,
-}
-
-/// Per-repository configuration entry in the YAML allowlist.
-///
-/// ```yaml
-/// repos:
-///   allowlist:
-///     - repo: "owner/name"
-///       skip_self_authored: false
-///       skip_reviewer_check: true
-///       review_on_push: false
-///       command: "claude code review"
-///       max_concurrency: 3
-///       base_repo_path: "/path/to/local/clone"
-/// ```
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RepoEntry {
-    /// Repository in `"owner/name"` format.
-    pub repo: String,
-
-    /// Skip PRs authored by the authenticated user. Default: true.
-    #[serde(default = "default_true")]
-    pub skip_self_authored: bool,
-
-    /// Process all open PRs regardless of reviewer assignment. Default: false.
-    /// When true, PRs are picked up even if the authenticated user is not
-    /// in the `requested_reviewers` list. Useful for self-review workflows.
-    #[serde(default)]
-    pub skip_reviewer_check: bool,
-
-    /// Re-review on every push (force-push / additional commit). Default: true.
-    /// When false, a PR with a prior succeeded review is not re-queued on SHA
-    /// change, but in-flight reviews on stale SHAs are still canceled.
-    #[serde(default = "default_true")]
-    pub review_on_push: bool,
-
-    /// Override the global `runner.agent` for this repo.
-    #[serde(default)]
-    pub agent: Option<crate::types::AgentKind>,
-
-    /// Override the global `runner.prompt_template` for this repo.
-    #[serde(default)]
-    pub prompt_template: Option<String>,
-
-    /// Override the global `runner.model` for this repo.
-    #[serde(default)]
-    pub model: Option<String>,
-
-    /// Override the global `execution.max_concurrency` for this repo.
-    /// Reserved for future use; not yet wired into the runner.
-    #[serde(default)]
-    pub max_concurrency: Option<usize>,
-
-    /// Path to the local clone of this repository.
-    /// Overrides the global `execution.base_repo_path` for worktree creation.
-    #[serde(default)]
-    pub base_repo_path: Option<PathBuf>,
-
-    /// PR numbers to exclude from review.
-    #[serde(default)]
-    pub ignore_prs: Vec<u64>,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-/// Parsed per-repository policy with a resolved `RepoId`.
-#[derive(Debug, Clone)]
-pub struct RepoPolicy {
-    pub id: crate::types::RepoId,
-    pub skip_self_authored: bool,
-    pub skip_reviewer_check: bool,
-    pub review_on_push: bool,
-    pub agent: Option<crate::types::AgentKind>,
-    pub prompt_template: Option<String>,
-    pub model: Option<String>,
-    /// Reserved for future use; not yet wired into the runner.
-    pub max_concurrency: Option<usize>,
-    /// Path to the local clone of this repository.
-    pub base_repo_path: Option<PathBuf>,
-    /// PR numbers to exclude from review.
-    pub ignore_prs: Vec<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -185,7 +148,6 @@ fn default_fallback_env() -> String {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionConfig {
-    pub base_repo_path: Option<PathBuf>,
     pub worktree_root: Option<PathBuf>,
 
     #[serde(default = "default_max_concurrency")]
@@ -198,7 +160,6 @@ pub struct ExecutionConfig {
 impl Default for ExecutionConfig {
     fn default() -> Self {
         Self {
-            base_repo_path: None,
             worktree_root: None,
             max_concurrency: default_max_concurrency(),
             lease_minutes: default_lease_minutes(),
@@ -237,24 +198,6 @@ fn default_max_concurrency() -> usize {
 
 fn default_lease_minutes() -> i64 {
     5
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RunnerConfig {
-    /// The agent to use for reviews (claude or codex). Default: claude.
-    #[serde(default)]
-    pub agent: Option<crate::types::AgentKind>,
-
-    /// Prompt template for the AI review agent.
-    /// Supports the same template variables as the command.
-    /// The rendered prompt is available as `{prompt}` and `{prompt_file}` in the command.
-    #[serde(default)]
-    pub prompt_template: Option<String>,
-
-    /// The model to pass to the agent via `--model` flag.
-    #[serde(default)]
-    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -377,7 +320,118 @@ fn default_output_dir() -> PathBuf {
 }
 
 // ---------------------------------------------------------------------------
-// Loading
+// Repos / per-repo policy
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReposConfig {
+    /// Template values that apply to every entry in `allowlist` unless the
+    /// entry overrides the same field.
+    #[serde(default)]
+    pub defaults: RepoDefaults,
+
+    /// Explicit list of repositories reviewq is allowed to process.
+    #[serde(default)]
+    pub allowlist: Vec<RepoEntry>,
+}
+
+/// User-level defaults for repo policy fields.
+///
+/// Every field is `Option<T>`. Unset fields fall back to built-in constants
+/// during resolution (see [`Config::repo_policies`]).
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepoDefaults {
+    #[serde(default)]
+    pub skip_self_authored: Option<bool>,
+
+    #[serde(default)]
+    pub skip_reviewer_check: Option<bool>,
+
+    #[serde(default)]
+    pub review_on_push: Option<bool>,
+
+    #[serde(default)]
+    pub agent: Option<crate::types::AgentKind>,
+
+    #[serde(default)]
+    pub prompt_template: Option<String>,
+
+    #[serde(default)]
+    pub model: Option<String>,
+
+    #[serde(default)]
+    pub base_repo_path: Option<PathBuf>,
+
+    #[serde(default)]
+    pub ignore_prs: Option<Vec<u64>>,
+}
+
+/// Per-repository configuration entry in the YAML allowlist.
+///
+/// ```yaml
+/// repos:
+///   allowlist:
+///     - repo: "owner/name"
+///       skip_self_authored: false
+///       skip_reviewer_check: true
+///       review_on_push: false
+///       agent: codex
+///       model: gpt-5.3-codex
+///       base_repo_path: "/path/to/local/clone"
+///       ignore_prs: [123, 456]
+/// ```
+///
+/// Any field left unset inherits from `repos.defaults`, and any field unset
+/// there falls back to a built-in constant.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepoEntry {
+    /// Repository in `"owner/name"` format.
+    pub repo: String,
+
+    #[serde(default)]
+    pub skip_self_authored: Option<bool>,
+
+    #[serde(default)]
+    pub skip_reviewer_check: Option<bool>,
+
+    #[serde(default)]
+    pub review_on_push: Option<bool>,
+
+    #[serde(default)]
+    pub agent: Option<crate::types::AgentKind>,
+
+    #[serde(default)]
+    pub prompt_template: Option<String>,
+
+    #[serde(default)]
+    pub model: Option<String>,
+
+    #[serde(default)]
+    pub base_repo_path: Option<PathBuf>,
+
+    #[serde(default)]
+    pub ignore_prs: Option<Vec<u64>>,
+}
+
+/// Per-repository policy with every field resolved to a concrete value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepoPolicy {
+    pub id: crate::types::RepoId,
+    pub skip_self_authored: bool,
+    pub skip_reviewer_check: bool,
+    pub review_on_push: bool,
+    pub agent: crate::types::AgentKind,
+    pub prompt_template: Option<String>,
+    pub model: Option<String>,
+    pub base_repo_path: Option<PathBuf>,
+    pub ignore_prs: Vec<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Loading, validation, resolution
 // ---------------------------------------------------------------------------
 
 impl Config {
@@ -423,13 +477,12 @@ impl Config {
             }
         }
 
-        // Validate model names (global and per-repo).
-        if let Some(ref m) = self.runner.model
+        // Validate model names (defaults and per-repo).
+        if let Some(ref m) = self.repos.defaults.model
             && !is_valid_model_name(m)
         {
             return Err(ReviewqError::Config(format!(
-                "invalid runner.model '{}': must match [A-Za-z0-9._:-]+",
-                m
+                "invalid repos.defaults.model '{m}': must match [A-Za-z0-9._:-]+"
             )));
         }
         for entry in &self.repos.allowlist {
@@ -443,9 +496,9 @@ impl Config {
             }
         }
 
-        if self.polling.interval_seconds == 0 {
+        if self.daemon.polling.interval_seconds == 0 {
             return Err(ReviewqError::Config(
-                "polling.interval_seconds must be > 0".into(),
+                "daemon.polling.interval_seconds must be > 0".into(),
             ));
         }
 
@@ -454,18 +507,29 @@ impl Config {
 
     /// Expand `~` in paths to the user's home directory.
     pub fn expand_paths(&mut self) {
-        if let Some(home) = dirs::home_dir() {
-            expand_tilde(&mut self.logging.dir, &home);
-            expand_tilde(&mut self.state.sqlite_path, &home);
-            expand_tilde(&mut self.output.dir, &home);
-            if let Some(ref mut p) = self.execution.worktree_root {
+        let Some(home) = dirs::home_dir() else { return };
+        expand_tilde(&mut self.daemon.logging.dir, &home);
+        expand_tilde(&mut self.daemon.state.sqlite_path, &home);
+        expand_tilde(&mut self.daemon.output.dir, &home);
+        if let Some(ref mut p) = self.daemon.execution.worktree_root {
+            expand_tilde(p, &home);
+        }
+        if let Some(ref mut p) = self.repos.defaults.base_repo_path {
+            expand_tilde(p, &home);
+        }
+        for entry in &mut self.repos.allowlist {
+            if let Some(ref mut p) = entry.base_repo_path {
                 expand_tilde(p, &home);
             }
         }
     }
 
-    /// Parse the allowlist into per-repository policies.
+    /// Resolve the allowlist into concrete per-repository policies.
+    ///
+    /// Resolution chain for each field: `RepoEntry` → `repos.defaults` →
+    /// built-in constant.
     pub fn repo_policies(&self) -> Vec<RepoPolicy> {
+        let d = &self.repos.defaults;
         self.repos
             .allowlist
             .iter()
@@ -473,18 +537,60 @@ impl Config {
                 let (owner, name) = entry.repo.split_once('/')?;
                 Some(RepoPolicy {
                     id: crate::types::RepoId::new(owner, name),
-                    skip_self_authored: entry.skip_self_authored,
-                    skip_reviewer_check: entry.skip_reviewer_check,
-                    review_on_push: entry.review_on_push,
-                    agent: entry.agent.clone(),
-                    prompt_template: entry.prompt_template.clone(),
-                    model: entry.model.clone(),
-                    max_concurrency: entry.max_concurrency,
-                    base_repo_path: entry.base_repo_path.clone(),
-                    ignore_prs: entry.ignore_prs.clone(),
+                    skip_self_authored: entry
+                        .skip_self_authored
+                        .or(d.skip_self_authored)
+                        .unwrap_or(BUILTIN_SKIP_SELF_AUTHORED),
+                    skip_reviewer_check: entry
+                        .skip_reviewer_check
+                        .or(d.skip_reviewer_check)
+                        .unwrap_or(BUILTIN_SKIP_REVIEWER_CHECK),
+                    review_on_push: entry
+                        .review_on_push
+                        .or(d.review_on_push)
+                        .unwrap_or(BUILTIN_REVIEW_ON_PUSH),
+                    agent: entry
+                        .agent
+                        .clone()
+                        .or_else(|| d.agent.clone())
+                        .unwrap_or_default(),
+                    prompt_template: entry
+                        .prompt_template
+                        .clone()
+                        .or_else(|| d.prompt_template.clone()),
+                    model: entry.model.clone().or_else(|| d.model.clone()),
+                    base_repo_path: entry
+                        .base_repo_path
+                        .clone()
+                        .or_else(|| d.base_repo_path.clone()),
+                    ignore_prs: entry
+                        .ignore_prs
+                        .clone()
+                        .or_else(|| d.ignore_prs.clone())
+                        .unwrap_or_default(),
                 })
             })
             .collect()
+    }
+
+    /// Extract just the repo IDs from the allowlist.
+    pub fn repo_ids(&self) -> Vec<crate::types::RepoId> {
+        self.repo_policies().into_iter().map(|p| p.id).collect()
+    }
+
+    /// Resolve the effective local clone path for a given repository.
+    ///
+    /// Priority: `RepoEntry.base_repo_path` > `repos.defaults.base_repo_path`.
+    ///
+    /// This re-runs `repo_policies()` on every call — intentionally simple
+    /// because it's called from convenience and test paths, never from the
+    /// runner's hot loop. The runner uses the already-materialized
+    /// `&[RepoPolicy]` slice directly.
+    pub fn base_repo_for(&self, repo: &crate::types::RepoId) -> Option<PathBuf> {
+        self.repo_policies()
+            .into_iter()
+            .find(|p| &p.id == repo)
+            .and_then(|p| p.base_repo_path)
     }
 
     /// Compare two configs and return human-readable change descriptions.
@@ -493,7 +599,74 @@ impl Config {
     pub fn diff_summary(old: &Config, new: &Config) -> Vec<String> {
         let mut changes = Vec::new();
 
-        if old.repos != new.repos {
+        // --- daemon ---
+        if old.daemon.polling != new.daemon.polling {
+            changes.push(format!(
+                "daemon.polling.interval_seconds changed: {} -> {}",
+                old.daemon.polling.interval_seconds, new.daemon.polling.interval_seconds
+            ));
+        }
+
+        if old.daemon.auth != new.daemon.auth {
+            changes.push("daemon.auth changed (restart required)".to_string());
+        }
+
+        if old.daemon.execution.max_concurrency != new.daemon.execution.max_concurrency {
+            changes.push(format!(
+                "daemon.execution.max_concurrency changed: {} -> {} (restart required)",
+                old.daemon.execution.max_concurrency, new.daemon.execution.max_concurrency
+            ));
+        }
+
+        if old.daemon.execution.worktree_root != new.daemon.execution.worktree_root {
+            changes.push(format!(
+                "daemon.execution.worktree_root changed: {:?} -> {:?}",
+                old.daemon.execution.worktree_root, new.daemon.execution.worktree_root
+            ));
+        }
+
+        if old.daemon.execution.lease_minutes != new.daemon.execution.lease_minutes {
+            changes.push(format!(
+                "daemon.execution.lease_minutes changed: {} -> {} (restart required)",
+                old.daemon.execution.lease_minutes, new.daemon.execution.lease_minutes
+            ));
+        }
+
+        if old.daemon.cancel != new.daemon.cancel {
+            changes.push("daemon.cancel changed (restart required)".to_string());
+        }
+
+        if old.daemon.cleanup != new.daemon.cleanup {
+            changes.push(format!(
+                "daemon.cleanup changed: ttl={}->{}min, interval={}->{}min",
+                old.daemon.cleanup.ttl_minutes,
+                new.daemon.cleanup.ttl_minutes,
+                old.daemon.cleanup.interval_minutes,
+                new.daemon.cleanup.interval_minutes
+            ));
+        }
+
+        if old.daemon.logging != new.daemon.logging {
+            changes.push("daemon.logging changed (restart required)".to_string());
+        }
+
+        if old.daemon.state != new.daemon.state {
+            changes.push("daemon.state changed (restart required)".to_string());
+        }
+
+        if old.daemon.output != new.daemon.output {
+            changes.push(format!(
+                "daemon.output.dir changed: {:?} -> {:?}",
+                old.daemon.output.dir, new.daemon.output.dir
+            ));
+        }
+
+        // --- repos ---
+        if old.repos.defaults != new.repos.defaults {
+            diff_repo_defaults(&old.repos.defaults, &new.repos.defaults, &mut changes);
+        }
+
+        if old.repos.allowlist != new.repos.allowlist {
             let old_repos: Vec<&str> = old
                 .repos
                 .allowlist
@@ -508,11 +681,11 @@ impl Config {
                 .collect();
             if old_repos != new_repos {
                 changes.push(format!(
-                    "repos.allowlist changed: {:?} -> {:?}",
-                    old_repos, new_repos
+                    "repos.allowlist changed: {old_repos:?} -> {new_repos:?}"
                 ));
             }
-            // Report per-repo review_on_push changes specifically.
+            // Report per-repo review_on_push changes specifically so the user
+            // sees exactly which repo toggled the flag.
             for new_entry in &new.repos.allowlist {
                 if let Some(old_entry) = old
                     .repos
@@ -522,14 +695,13 @@ impl Config {
                     .filter(|old_entry| old_entry.review_on_push != new_entry.review_on_push)
                 {
                     changes.push(format!(
-                        "repos.allowlist[{}].review_on_push changed: {} -> {}",
+                        "repos.allowlist[{}].review_on_push changed: {:?} -> {:?}",
                         new_entry.repo, old_entry.review_on_push, new_entry.review_on_push
                     ));
                 }
             }
             // Fallback: if repo list is the same but other per-repo settings
-            // changed (command, prompt_template, etc.), emit a generic line
-            // so the change isn't silently swallowed.
+            // changed, emit a generic line so the change isn't swallowed.
             if old_repos == new_repos {
                 let has_other_changes = new.repos.allowlist.iter().any(|new_entry| {
                     old.repos
@@ -542,7 +714,6 @@ impl Config {
                                 || old_entry.agent != new_entry.agent
                                 || old_entry.prompt_template != new_entry.prompt_template
                                 || old_entry.model != new_entry.model
-                                || old_entry.max_concurrency != new_entry.max_concurrency
                                 || old_entry.base_repo_path != new_entry.base_repo_path
                                 || old_entry.ignore_prs != new_entry.ignore_prs
                         })
@@ -553,105 +724,60 @@ impl Config {
             }
         }
 
-        if old.polling != new.polling {
-            changes.push(format!(
-                "polling.interval_seconds changed: {} -> {}",
-                old.polling.interval_seconds, new.polling.interval_seconds
-            ));
-        }
-
-        if old.auth != new.auth {
-            changes.push("auth changed (restart required)".to_string());
-        }
-
-        if old.execution.max_concurrency != new.execution.max_concurrency {
-            changes.push(format!(
-                "execution.max_concurrency changed: {} -> {} (restart required)",
-                old.execution.max_concurrency, new.execution.max_concurrency
-            ));
-        }
-
-        if old.execution.base_repo_path != new.execution.base_repo_path {
-            changes.push(format!(
-                "execution.base_repo_path changed: {:?} -> {:?}",
-                old.execution.base_repo_path, new.execution.base_repo_path
-            ));
-        }
-
-        if old.execution.worktree_root != new.execution.worktree_root {
-            changes.push(format!(
-                "execution.worktree_root changed: {:?} -> {:?}",
-                old.execution.worktree_root, new.execution.worktree_root
-            ));
-        }
-
-        if old.runner.agent != new.runner.agent {
-            changes.push(format!(
-                "runner.agent changed: {:?} -> {:?} (restart required)",
-                old.runner.agent, new.runner.agent
-            ));
-        }
-
-        if old.runner.prompt_template != new.runner.prompt_template {
-            changes.push(format!(
-                "runner.prompt_template changed: {:?} -> {:?}",
-                old.runner.prompt_template, new.runner.prompt_template
-            ));
-        }
-
-        if old.runner.model != new.runner.model {
-            changes.push(format!(
-                "runner.model changed: {:?} -> {:?}",
-                old.runner.model, new.runner.model
-            ));
-        }
-
-        if old.cancel != new.cancel {
-            changes.push("cancel changed (restart required)".to_string());
-        }
-
-        if old.cleanup != new.cleanup {
-            changes.push(format!(
-                "cleanup changed: ttl={}->{}min, interval={}->{}min",
-                old.cleanup.ttl_minutes,
-                new.cleanup.ttl_minutes,
-                old.cleanup.interval_minutes,
-                new.cleanup.interval_minutes
-            ));
-        }
-
-        if old.logging != new.logging {
-            changes.push("logging changed (restart required)".to_string());
-        }
-
-        if old.state != new.state {
-            changes.push("state changed (restart required)".to_string());
-        }
-
-        if old.output != new.output {
-            changes.push(format!(
-                "output.dir changed: {:?} -> {:?}",
-                old.output.dir, new.output.dir
-            ));
-        }
-
         changes
     }
+}
 
-    /// Extract just the repo IDs from the allowlist.
-    pub fn repo_ids(&self) -> Vec<crate::types::RepoId> {
-        self.repo_policies().into_iter().map(|p| p.id).collect()
+/// Emit a line per field that differs between the two `RepoDefaults`
+/// instances so hot-reload observers can see *which* default flipped.
+fn diff_repo_defaults(old: &RepoDefaults, new: &RepoDefaults, changes: &mut Vec<String>) {
+    if old.skip_self_authored != new.skip_self_authored {
+        changes.push(format!(
+            "repos.defaults.skip_self_authored changed: {:?} -> {:?}",
+            old.skip_self_authored, new.skip_self_authored
+        ));
     }
-
-    /// Resolve the local clone path for a given repository.
-    ///
-    /// Priority: per-repo `base_repo_path` > global `execution.base_repo_path`.
-    pub fn base_repo_for(&self, repo: &crate::types::RepoId) -> Option<PathBuf> {
-        self.repo_policies()
-            .iter()
-            .find(|p| &p.id == repo)
-            .and_then(|p| p.base_repo_path.clone())
-            .or_else(|| self.execution.base_repo_path.clone())
+    if old.skip_reviewer_check != new.skip_reviewer_check {
+        changes.push(format!(
+            "repos.defaults.skip_reviewer_check changed: {:?} -> {:?}",
+            old.skip_reviewer_check, new.skip_reviewer_check
+        ));
+    }
+    if old.review_on_push != new.review_on_push {
+        changes.push(format!(
+            "repos.defaults.review_on_push changed: {:?} -> {:?}",
+            old.review_on_push, new.review_on_push
+        ));
+    }
+    if old.agent != new.agent {
+        changes.push(format!(
+            "repos.defaults.agent changed: {:?} -> {:?}",
+            old.agent, new.agent
+        ));
+    }
+    if old.prompt_template != new.prompt_template {
+        changes.push(format!(
+            "repos.defaults.prompt_template changed: {:?} -> {:?}",
+            old.prompt_template, new.prompt_template
+        ));
+    }
+    if old.model != new.model {
+        changes.push(format!(
+            "repos.defaults.model changed: {:?} -> {:?}",
+            old.model, new.model
+        ));
+    }
+    if old.base_repo_path != new.base_repo_path {
+        changes.push(format!(
+            "repos.defaults.base_repo_path changed: {:?} -> {:?}",
+            old.base_repo_path, new.base_repo_path
+        ));
+    }
+    if old.ignore_prs != new.ignore_prs {
+        changes.push(format!(
+            "repos.defaults.ignore_prs changed: {:?} -> {:?}",
+            old.ignore_prs, new.ignore_prs
+        ));
     }
 }
 
@@ -677,6 +803,9 @@ fn expand_tilde(path: &mut PathBuf, home: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{AgentKind, RepoId};
+
+    // -- parsing --------------------------------------------------------
 
     #[test]
     fn parse_minimal_config() {
@@ -688,11 +817,10 @@ repos:
         let config = Config::from_yaml(yaml).expect("should parse");
         assert_eq!(config.repos.allowlist.len(), 1);
         assert_eq!(config.repos.allowlist[0].repo, "owner/repo");
-        assert!(config.repos.allowlist[0].skip_self_authored);
+        assert!(config.repos.allowlist[0].skip_self_authored.is_none());
         assert!(config.repos.allowlist[0].agent.is_none());
-        assert!(config.repos.allowlist[0].max_concurrency.is_none());
-        assert_eq!(config.polling.interval_seconds, 300);
-        assert_eq!(config.execution.max_concurrency, 10);
+        assert_eq!(config.daemon.polling.interval_seconds, 300);
+        assert_eq!(config.daemon.execution.max_concurrency, 10);
     }
 
     #[test]
@@ -703,7 +831,6 @@ repos:
     - repo: org/repo1
       skip_self_authored: false
       agent: codex
-      max_concurrency: 3
     - repo: org/repo2
 "#;
         let config = Config::from_yaml(yaml).expect("should parse");
@@ -711,34 +838,167 @@ repos:
 
         let e0 = &config.repos.allowlist[0];
         assert_eq!(e0.repo, "org/repo1");
-        assert!(!e0.skip_self_authored);
-        assert_eq!(e0.agent, Some(crate::types::AgentKind::Codex));
-        assert_eq!(e0.max_concurrency, Some(3));
+        assert_eq!(e0.skip_self_authored, Some(false));
+        assert_eq!(e0.agent, Some(AgentKind::Codex));
 
         let e1 = &config.repos.allowlist[1];
         assert_eq!(e1.repo, "org/repo2");
-        assert!(e1.skip_self_authored);
+        assert!(e1.skip_self_authored.is_none());
         assert!(e1.agent.is_none());
-        assert!(e1.max_concurrency.is_none());
     }
 
     #[test]
-    fn repo_policies_returns_parsed_entries() {
+    fn parse_full_daemon_and_repos() {
+        let yaml = r#"
+daemon:
+  polling:
+    interval_seconds: 60
+  auth:
+    method: gh
+    fallback_env: GITHUB_TOKEN
+  execution:
+    max_concurrency: 5
+    lease_minutes: 10
+  cancel:
+    sigint_timeout_seconds: 3
+    sigterm_timeout_seconds: 10
+    sigkill_timeout_seconds: 3
+  cleanup:
+    ttl_minutes: 720
+    interval_minutes: 15
+
+repos:
+  defaults:
+    agent: codex
+  allowlist:
+    - repo: org/repo1
+    - repo: org/repo2
+"#;
+        let config = Config::from_yaml(yaml).expect("should parse");
+        assert_eq!(config.daemon.polling.interval_seconds, 60);
+        assert_eq!(config.daemon.execution.max_concurrency, 5);
+        assert_eq!(config.daemon.execution.lease_minutes, 10);
+        assert_eq!(config.daemon.cancel.sigint_timeout_seconds, 3);
+        assert_eq!(config.daemon.cleanup.ttl_minutes, 720);
+        assert_eq!(config.repos.defaults.agent, Some(AgentKind::Codex));
+    }
+
+    // -- resolution chain -----------------------------------------------
+
+    #[test]
+    fn resolve_falls_back_to_builtin_when_nothing_set() {
         let yaml = r#"
 repos:
   allowlist:
     - repo: org/repo
-      skip_self_authored: false
-      agent: codex
-      max_concurrency: 2
 "#;
-        let config = Config::from_yaml(yaml).expect("should parse");
+        let config = Config::from_yaml(yaml).expect("parse");
         let policies = config.repo_policies();
         assert_eq!(policies.len(), 1);
-        assert_eq!(policies[0].id, crate::types::RepoId::new("org", "repo"));
-        assert!(!policies[0].skip_self_authored);
-        assert_eq!(policies[0].agent, Some(crate::types::AgentKind::Codex));
-        assert_eq!(policies[0].max_concurrency, Some(2));
+        let p = &policies[0];
+        assert_eq!(p.id, RepoId::new("org", "repo"));
+        assert!(p.skip_self_authored);
+        assert!(!p.skip_reviewer_check);
+        assert!(p.review_on_push);
+        assert_eq!(p.agent, AgentKind::Claude);
+        assert!(p.prompt_template.is_none());
+        assert!(p.model.is_none());
+        assert!(p.base_repo_path.is_none());
+        assert!(p.ignore_prs.is_empty());
+    }
+
+    #[test]
+    fn resolve_uses_repos_defaults_when_entry_is_silent() {
+        let yaml = r#"
+repos:
+  defaults:
+    agent: codex
+    model: gpt-5.3-codex
+    prompt_template: "Review {pr_url}"
+    base_repo_path: /shared/src
+    skip_self_authored: false
+    ignore_prs: [1, 2]
+  allowlist:
+    - repo: org/repo
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        let p = &config.repo_policies()[0];
+        assert_eq!(p.agent, AgentKind::Codex);
+        assert_eq!(p.model.as_deref(), Some("gpt-5.3-codex"));
+        assert_eq!(p.prompt_template.as_deref(), Some("Review {pr_url}"));
+        assert_eq!(p.base_repo_path, Some(PathBuf::from("/shared/src")));
+        assert!(!p.skip_self_authored);
+        assert_eq!(p.ignore_prs, vec![1, 2]);
+    }
+
+    #[test]
+    fn resolve_entry_overrides_defaults() {
+        let yaml = r#"
+repos:
+  defaults:
+    agent: codex
+    model: gpt-5.3-codex
+    base_repo_path: /shared/src
+  allowlist:
+    - repo: org/repo-a
+    - repo: org/repo-b
+      agent: claude
+      model: claude-sonnet-4-6
+      base_repo_path: /custom/src
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        let policies = config.repo_policies();
+        assert_eq!(policies.len(), 2);
+
+        // repo-a inherits everything from defaults
+        assert_eq!(policies[0].agent, AgentKind::Codex);
+        assert_eq!(policies[0].model.as_deref(), Some("gpt-5.3-codex"));
+        assert_eq!(
+            policies[0].base_repo_path,
+            Some(PathBuf::from("/shared/src"))
+        );
+
+        // repo-b overrides
+        assert_eq!(policies[1].agent, AgentKind::Claude);
+        assert_eq!(policies[1].model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(
+            policies[1].base_repo_path,
+            Some(PathBuf::from("/custom/src"))
+        );
+    }
+
+    #[test]
+    fn builtin_skip_self_authored_is_true() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        assert!(config.repo_policies()[0].skip_self_authored);
+    }
+
+    #[test]
+    fn builtin_review_on_push_is_true() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        assert!(config.repo_policies()[0].review_on_push);
+    }
+
+    #[test]
+    fn entry_can_disable_review_on_push() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+      review_on_push: false
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        assert!(!config.repo_policies()[0].review_on_push);
     }
 
     #[test]
@@ -749,12 +1009,48 @@ repos:
     - repo: org/repo1
     - repo: org/repo2
 "#;
-        let config = Config::from_yaml(yaml).expect("should parse");
+        let config = Config::from_yaml(yaml).expect("parse");
         let ids = config.repo_ids();
         assert_eq!(ids.len(), 2);
-        assert_eq!(ids[0], crate::types::RepoId::new("org", "repo1"));
-        assert_eq!(ids[1], crate::types::RepoId::new("org", "repo2"));
+        assert_eq!(ids[0], RepoId::new("org", "repo1"));
+        assert_eq!(ids[1], RepoId::new("org", "repo2"));
     }
+
+    #[test]
+    fn base_repo_for_prefers_entry_then_defaults() {
+        let yaml = r#"
+repos:
+  defaults:
+    base_repo_path: /shared/src
+  allowlist:
+    - repo: org/repo-a
+    - repo: org/repo-b
+      base_repo_path: /custom/src
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        assert_eq!(
+            config.base_repo_for(&RepoId::new("org", "repo-a")),
+            Some(PathBuf::from("/shared/src"))
+        );
+        assert_eq!(
+            config.base_repo_for(&RepoId::new("org", "repo-b")),
+            Some(PathBuf::from("/custom/src"))
+        );
+        assert_eq!(config.base_repo_for(&RepoId::new("org", "unknown")), None);
+    }
+
+    #[test]
+    fn base_repo_for_returns_none_when_nothing_set() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+"#;
+        let config = Config::from_yaml(yaml).expect("parse");
+        assert_eq!(config.base_repo_for(&RepoId::new("org", "repo")), None);
+    }
+
+    // -- validation -----------------------------------------------------
 
     #[test]
     fn reject_empty_allowlist() {
@@ -790,78 +1086,87 @@ repos:
     }
 
     #[test]
-    fn parse_prompt_template_in_runner() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: owner/repo
-runner:
-  agent: claude
-  prompt_template: "Review {pr_url}"
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert_eq!(
-            config.runner.prompt_template.as_deref(),
-            Some("Review {pr_url}")
-        );
-        assert_eq!(config.runner.agent, Some(crate::types::AgentKind::Claude));
+    fn valid_model_names_accepted() {
+        for name in [
+            "claude-sonnet-4-5-20250514",
+            "gpt-5.3-codex",
+            "gpt-5.4",
+            "model:v1.2",
+            "a_b-c.d:e",
+        ] {
+            let yaml = format!(
+                "repos:\n  defaults:\n    model: {name}\n  allowlist:\n    - repo: org/repo\n"
+            );
+            Config::from_yaml(&yaml)
+                .unwrap_or_else(|e| panic!("model '{name}' should be valid: {e}"));
+        }
     }
 
     #[test]
-    fn parse_per_repo_prompt_template() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo1
-      prompt_template: "Custom prompt for repo1"
-    - repo: org/repo2
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        let policies = config.repo_policies();
-        assert_eq!(
-            policies[0].prompt_template.as_deref(),
-            Some("Custom prompt for repo1")
-        );
-        assert!(policies[1].prompt_template.is_none());
+    fn invalid_defaults_model_rejected() {
+        for name in ["model name", "model;rm", "$(echo hi)", "mod\"el", ""] {
+            let yaml = format!(
+                "repos:\n  defaults:\n    model: \"{name}\"\n  allowlist:\n    - repo: org/repo\n"
+            );
+            assert!(
+                Config::from_yaml(&yaml).is_err(),
+                "model '{name}' should be rejected"
+            );
+        }
     }
 
     #[test]
-    fn full_config_roundtrip() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo1
-    - repo: org/repo2
-polling:
-  interval_seconds: 60
-auth:
-  method: gh
-  fallback_env: GITHUB_TOKEN
-execution:
-  max_concurrency: 5
-cancel:
-  sigint_timeout_seconds: 3
-  sigterm_timeout_seconds: 10
-  sigkill_timeout_seconds: 3
-cleanup:
-  ttl_minutes: 720
-  interval_minutes: 15
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert_eq!(config.polling.interval_seconds, 60);
-        assert_eq!(config.execution.max_concurrency, 5);
-        assert_eq!(config.cancel.sigint_timeout_seconds, 3);
-        assert_eq!(config.cleanup.ttl_minutes, 720);
-    }
-
-    #[test]
-    fn diff_summary_no_changes() {
+    fn invalid_per_repo_model_rejected() {
         let yaml = r#"
 repos:
   allowlist:
     - repo: org/repo
-polling:
-  interval_seconds: 60
+      model: "bad model"
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("invalid model"));
+    }
+
+    #[test]
+    fn reject_unknown_top_level_key() {
+        // The old schema used `runner:` / `polling:` / etc. at the top level.
+        // With the new schema they must live under `daemon:` and the old
+        // layout should fail to parse.
+        let yaml = r#"
+runner:
+  agent: claude
+repos:
+  allowlist:
+    - repo: org/repo
+"#;
+        assert!(Config::from_yaml(yaml).is_err());
+    }
+
+    #[test]
+    fn reject_zero_polling_interval() {
+        let yaml = r#"
+daemon:
+  polling:
+    interval_seconds: 0
+repos:
+  allowlist:
+    - repo: org/repo
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("polling"));
+    }
+
+    // -- diff_summary ---------------------------------------------------
+
+    #[test]
+    fn diff_summary_no_changes() {
+        let yaml = r#"
+daemon:
+  polling:
+    interval_seconds: 60
+repos:
+  allowlist:
+    - repo: org/repo
 "#;
         let config = Config::from_yaml(yaml).expect("parse");
         let changes = Config::diff_summary(&config, &config);
@@ -872,50 +1177,54 @@ polling:
     fn diff_summary_detects_polling_change() {
         let old = Config::from_yaml(
             r#"
+daemon:
+  polling:
+    interval_seconds: 60
 repos:
   allowlist:
     - repo: org/repo
-polling:
-  interval_seconds: 60
 "#,
         )
         .expect("parse");
         let new = Config::from_yaml(
             r#"
+daemon:
+  polling:
+    interval_seconds: 120
 repos:
   allowlist:
     - repo: org/repo
-polling:
-  interval_seconds: 120
 "#,
         )
         .expect("parse");
         let changes = Config::diff_summary(&old, &new);
         assert_eq!(changes.len(), 1);
-        assert!(changes[0].contains("polling.interval_seconds"));
+        assert!(changes[0].contains("daemon.polling.interval_seconds"));
         assert!(changes[0].contains("60"));
         assert!(changes[0].contains("120"));
     }
 
     #[test]
-    fn diff_summary_detects_restart_required() {
+    fn diff_summary_detects_max_concurrency_restart_required() {
         let old = Config::from_yaml(
             r#"
+daemon:
+  execution:
+    max_concurrency: 5
 repos:
   allowlist:
     - repo: org/repo
-execution:
-  max_concurrency: 5
 "#,
         )
         .expect("parse");
         let new = Config::from_yaml(
             r#"
+daemon:
+  execution:
+    max_concurrency: 20
 repos:
   allowlist:
     - repo: org/repo
-execution:
-  max_concurrency: 20
 "#,
         )
         .expect("parse");
@@ -928,7 +1237,7 @@ execution:
     }
 
     #[test]
-    fn diff_summary_detects_repo_change() {
+    fn diff_summary_detects_repo_list_change() {
         let old = Config::from_yaml(
             r#"
 repos:
@@ -947,67 +1256,6 @@ repos:
         .expect("parse");
         let changes = Config::diff_summary(&old, &new);
         assert!(changes.iter().any(|c| c.contains("repos.allowlist")));
-    }
-
-    #[test]
-    fn diff_summary_multiple_changes() {
-        let old = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-polling:
-  interval_seconds: 60
-cleanup:
-  ttl_minutes: 1440
-  interval_minutes: 30
-"#,
-        )
-        .expect("parse");
-        let new = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-polling:
-  interval_seconds: 120
-cleanup:
-  ttl_minutes: 720
-  interval_minutes: 15
-"#,
-        )
-        .expect("parse");
-        let changes = Config::diff_summary(&old, &new);
-        assert_eq!(changes.len(), 2);
-        assert!(changes.iter().any(|c| c.contains("polling")));
-        assert!(changes.iter().any(|c| c.contains("cleanup")));
-    }
-
-    #[test]
-    fn parse_review_on_push_false() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo
-      review_on_push: false
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert!(!config.repos.allowlist[0].review_on_push);
-        let policies = config.repo_policies();
-        assert!(!policies[0].review_on_push);
-    }
-
-    #[test]
-    fn review_on_push_defaults_to_true() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert!(config.repos.allowlist[0].review_on_push);
-        let policies = config.repo_policies();
-        assert!(policies[0].review_on_push);
     }
 
     #[test]
@@ -1031,152 +1279,81 @@ repos:
         )
         .expect("parse");
         let changes = Config::diff_summary(&old, &new);
-        assert_eq!(changes.len(), 1);
-        assert!(changes[0].contains("review_on_push"));
-        assert!(changes[0].contains("true"));
-        assert!(changes[0].contains("false"));
-        // Should not have a generic "repos.allowlist changed" line
-        // since the repo list itself didn't change.
-        assert!(!changes[0].contains("repos.allowlist changed"));
+        assert!(changes.iter().any(|c| c.contains("review_on_push")));
     }
 
     #[test]
-    fn diff_summary_review_on_push_and_agent_both_changed() {
+    fn diff_summary_detects_repos_defaults_agent_change() {
         let old = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    agent: claude
   allowlist:
     - repo: org/repo
-      review_on_push: true
-      agent: claude
 "#,
         )
         .expect("parse");
         let new = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    agent: codex
   allowlist:
     - repo: org/repo
-      review_on_push: false
-      agent: codex
 "#,
         )
         .expect("parse");
         let changes = Config::diff_summary(&old, &new);
-        // Should have 2 lines: specific review_on_push + generic per-repo settings
-        assert_eq!(changes.len(), 2);
-        assert!(changes.iter().any(|c| c.contains("review_on_push")));
+        // Must name the specific field that flipped, not a coarse
+        // "repos.defaults changed" line.
+        assert!(
+            changes.iter().any(|c| c.contains("repos.defaults.agent")
+                && c.contains("Claude")
+                && c.contains("Codex")),
+            "expected field-level diff for agent: {changes:?}"
+        );
+    }
+
+    #[test]
+    fn diff_summary_detects_repos_defaults_model_and_prompt_changes() {
+        let old = Config::from_yaml(
+            r#"
+repos:
+  defaults:
+    model: gpt-5.3-codex
+    prompt_template: "old"
+  allowlist:
+    - repo: org/repo
+"#,
+        )
+        .expect("parse");
+        let new = Config::from_yaml(
+            r#"
+repos:
+  defaults:
+    model: gpt-5.4
+    prompt_template: "new"
+  allowlist:
+    - repo: org/repo
+"#,
+        )
+        .expect("parse");
+        let changes = Config::diff_summary(&old, &new);
+        assert!(
+            changes.iter().any(|c| c.contains("repos.defaults.model")),
+            "expected model diff: {changes:?}"
+        );
         assert!(
             changes
                 .iter()
-                .any(|c| c.contains("per-repo settings changed"))
+                .any(|c| c.contains("repos.defaults.prompt_template")),
+            "expected prompt_template diff: {changes:?}"
         );
     }
 
     #[test]
-    fn parse_model_in_runner() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: owner/repo
-runner:
-  model: claude-sonnet-4-5-20250514
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert_eq!(
-            config.runner.model.as_deref(),
-            Some("claude-sonnet-4-5-20250514")
-        );
-    }
-
-    #[test]
-    fn parse_per_repo_model() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo1
-      model: gpt-5.3-codex
-    - repo: org/repo2
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        let policies = config.repo_policies();
-        assert_eq!(policies[0].model.as_deref(), Some("gpt-5.3-codex"));
-        assert!(policies[1].model.is_none());
-    }
-
-    #[test]
-    fn valid_model_names_accepted() {
-        for name in [
-            "claude-sonnet-4-5-20250514",
-            "gpt-5.3-codex",
-            "gpt-5.4",
-            "model:v1.2",
-            "a_b-c.d:e",
-        ] {
-            let yaml =
-                format!("repos:\n  allowlist:\n    - repo: org/repo\nrunner:\n  model: {name}\n");
-            Config::from_yaml(&yaml)
-                .unwrap_or_else(|e| panic!("model '{name}' should be valid: {e}"));
-        }
-    }
-
-    #[test]
-    fn invalid_model_names_rejected() {
-        for name in ["model name", "model;rm", "$(echo hi)", "mod\"el", ""] {
-            let yaml = format!(
-                "repos:\n  allowlist:\n    - repo: org/repo\nrunner:\n  model: \"{name}\"\n"
-            );
-            assert!(
-                Config::from_yaml(&yaml).is_err(),
-                "model '{name}' should be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn invalid_per_repo_model_rejected() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo
-      model: "bad model"
-"#;
-        let err = Config::from_yaml(yaml).unwrap_err();
-        assert!(err.to_string().contains("invalid model"));
-    }
-
-    #[test]
-    fn diff_summary_detects_runner_model_change() {
-        let old = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-runner:
-  model: gpt-5.4
-"#,
-        )
-        .expect("parse");
-        let new = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-runner:
-  model: gpt-5.3-codex
-"#,
-        )
-        .expect("parse");
-        let changes = Config::diff_summary(&old, &new);
-        assert!(
-            changes.iter().any(|c| c.contains("runner.model")),
-            "should detect runner.model change: {:?}",
-            changes
-        );
-    }
-
-    #[test]
-    fn diff_summary_detects_per_repo_model_change() {
+    fn diff_summary_detects_per_repo_settings_change_fallback() {
         let old = Config::from_yaml(
             r#"
 repos:
@@ -1199,87 +1376,36 @@ repos:
         assert!(
             changes
                 .iter()
-                .any(|c| c.contains("per-repo settings changed")),
-            "should detect per-repo model change: {:?}",
-            changes
+                .any(|c| c.contains("per-repo settings changed"))
         );
     }
 
-    #[test]
-    fn diff_summary_only_agent_changed() {
-        let old = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-      agent: claude
-"#,
-        )
-        .expect("parse");
-        let new = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-      agent: codex
-"#,
-        )
-        .expect("parse");
-        let changes = Config::diff_summary(&old, &new);
-        // Should have the fallback line for other per-repo settings
-        assert_eq!(changes.len(), 1);
-        assert!(changes[0].contains("per-repo settings changed"));
-    }
+    // -- expand_paths ---------------------------------------------------
 
     #[test]
-    fn parse_ignore_prs() {
+    fn expand_paths_expands_tilde_in_base_repo_paths() {
+        // Skip the test when the home directory cannot be resolved (e.g. in
+        // sandboxed CI).
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: ~/src/defaults
   allowlist:
     - repo: org/repo
-      ignore_prs: [9520, 9521, 9522]
+      base_repo_path: ~/src/custom
 "#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert_eq!(config.repos.allowlist[0].ignore_prs, vec![9520, 9521, 9522]);
-        let policies = config.repo_policies();
-        assert_eq!(policies[0].ignore_prs, vec![9520, 9521, 9522]);
-    }
-
-    #[test]
-    fn ignore_prs_defaults_to_empty() {
-        let yaml = r#"
-repos:
-  allowlist:
-    - repo: org/repo
-"#;
-        let config = Config::from_yaml(yaml).expect("should parse");
-        assert!(config.repos.allowlist[0].ignore_prs.is_empty());
-    }
-
-    #[test]
-    fn diff_summary_detects_ignore_prs_change() {
-        let old = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-"#,
-        )
-        .expect("parse");
-        let new = Config::from_yaml(
-            r#"
-repos:
-  allowlist:
-    - repo: org/repo
-      ignore_prs: [100]
-"#,
-        )
-        .expect("parse");
-        let changes = Config::diff_summary(&old, &new);
-        assert!(
-            changes
-                .iter()
-                .any(|c| c.contains("per-repo settings changed")),
+        let mut config = Config::from_yaml(yaml).expect("parse");
+        config.expand_paths();
+        assert_eq!(
+            config.repos.defaults.base_repo_path.as_deref(),
+            Some(home.join("src/defaults").as_path())
+        );
+        assert_eq!(
+            config.repos.allowlist[0].base_repo_path.as_deref(),
+            Some(home.join("src/custom").as_path())
         );
     }
 }

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -34,7 +34,7 @@ where
         let policies = config.repo_policies();
         let repo_ids: Vec<RepoId> = policies.iter().map(|p| p.id.clone()).collect();
 
-        match detect_once(github, store, &config, &username, &repo_ids, &policies).await {
+        match detect_once(github, store, &username, &repo_ids, &policies).await {
             Ok(count) => info!(new_jobs = count, "detection cycle complete"),
             Err(e) => {
                 if e.is_retryable() {
@@ -44,7 +44,7 @@ where
                 }
             }
         }
-        sleep(Duration::from_secs(config.polling.interval_seconds)).await;
+        sleep(Duration::from_secs(config.daemon.polling.interval_seconds)).await;
     }
 }
 
@@ -52,7 +52,6 @@ where
 async fn detect_once<G, S>(
     github: &G,
     store: &S,
-    config: &Config,
     username: &str,
     repo_ids: &[RepoId],
     policies: &[RepoPolicy],
@@ -92,11 +91,15 @@ where
 
     info!(pr_count = prs.len(), "fetched PRs from GitHub");
 
-    let global_agent = config.runner.agent.clone().unwrap_or_default();
     let mut enqueued = 0;
 
     for pr in &prs {
-        // Look up per-repo policy.
+        // Look up per-repo policy. Every field here is already resolved
+        // through `RepoEntry -> repos.defaults -> built-in` in
+        // `Config::repo_policies`, so no merge logic is needed at this
+        // layer. The `Option` only exists because a PR could, in theory,
+        // arrive for a repo that isn't in the allowlist — in practice the
+        // detector only fetches PRs for allowlisted repos.
         let policy = policies.iter().find(|p| p.id == pr.repo);
         let skip_self = policy.is_none_or(|p| p.skip_self_authored);
         let skip_reviewer = policy.is_some_and(|p| p.skip_reviewer_check);
@@ -115,10 +118,8 @@ where
             continue;
         }
 
-        // Resolve agent kind: per-repo override > global config > default (Claude).
-        let agent_kind = policy
-            .and_then(|p| p.agent.clone())
-            .unwrap_or_else(|| global_agent.clone());
+        // Resolve agent kind directly from the policy (already merged).
+        let agent_kind = policy.map(|p| p.agent.clone()).unwrap_or_default();
 
         // Handle SHA changes (cancel stale jobs) — always runs regardless
         // of review_on_push to prevent stale reviews from completing.
@@ -143,18 +144,13 @@ where
             continue;
         }
 
-        // Resolve model: per-repo override > global runner.model.
-        let model = policy
-            .and_then(|p| p.model.clone())
-            .or_else(|| config.runner.model.clone());
+        // Model and prompt_template are already resolved in the policy.
+        let model = policy.and_then(|p| p.model.clone());
 
         // Generate command from resolved agent kind and model.
         let command = Some(agent_kind.default_command(model.as_deref()));
 
-        // Resolve prompt_template: per-repo override > global runner.prompt_template.
-        let prompt_template = policy
-            .and_then(|p| p.prompt_template.clone())
-            .or_else(|| config.runner.prompt_template.clone());
+        let prompt_template = policy.and_then(|p| p.prompt_template.clone());
 
         // Enqueue new job
         let new_job = NewJob {
@@ -238,8 +234,9 @@ mod tests {
 repos:
   allowlist:
     - repo: org/repo
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config should parse")
@@ -252,8 +249,9 @@ repos:
   allowlist:
     - repo: org/repo
       skip_self_authored: false
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config should parse")
@@ -283,7 +281,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -306,13 +304,13 @@ polling:
         let repo_ids = config.repo_ids();
 
         // First cycle should enqueue
-        let count1 = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
 
         // Second cycle should skip (idempotent)
-        let count2 = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 0);
@@ -329,7 +327,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "alice", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "alice", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0);
@@ -348,7 +346,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "alice", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "alice", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -364,20 +362,21 @@ polling:
         let config = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    agent: claude
   allowlist:
     - repo: org/repo
       agent: codex
-runner:
-  agent: claude
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config");
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -401,19 +400,20 @@ polling:
         let config = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    agent: codex
   allowlist:
     - repo: org/repo
-runner:
-  agent: codex
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config");
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -437,20 +437,21 @@ polling:
         let config = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    prompt_template: "global-prompt"
   allowlist:
     - repo: org/repo
       prompt_template: "per-repo-prompt"
-runner:
-  prompt_template: "global-prompt"
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config");
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -469,19 +470,20 @@ polling:
         let config = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    prompt_template: "global-prompt"
   allowlist:
     - repo: org/repo
-runner:
-  prompt_template: "global-prompt"
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config");
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -501,7 +503,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -523,7 +525,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0);
@@ -541,7 +543,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -551,7 +553,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 1);
@@ -572,7 +574,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0);
@@ -586,8 +588,9 @@ repos:
     - repo: org/repo
       skip_self_authored: false
       skip_reviewer_check: true
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config should parse")
@@ -610,7 +613,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "alice", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "alice", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -627,8 +630,9 @@ repos:
   allowlist:
     - repo: org/repo
       review_on_push: false
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config should parse")
@@ -646,7 +650,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -661,7 +665,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 0, "succeeded PR should not be re-queued");
@@ -679,7 +683,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -690,7 +694,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(
@@ -708,7 +712,7 @@ polling:
         db.cancel_queued_requested().expect("sweep");
 
         // Third cycle: now the old job is canceled, new job should be enqueued.
-        let count3 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count3 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(
@@ -729,7 +733,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -743,7 +747,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 1, "failed job should allow retry");
@@ -762,7 +766,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -776,7 +780,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count2, 1, "default behavior should re-queue on SHA change");
@@ -794,7 +798,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -809,7 +813,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(
@@ -828,7 +832,7 @@ polling:
             .expect("complete canceled");
 
         // Third cycle: now the old job is canceled, new job should be enqueued.
-        let count3 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count3 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(
@@ -847,20 +851,21 @@ polling:
         let config = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    model: gpt-5.4
   allowlist:
     - repo: org/repo
       model: gpt-5.3-codex
-runner:
-  model: gpt-5.4
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config");
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -887,19 +892,20 @@ polling:
         let config = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    model: gpt-5.4
   allowlist:
     - repo: org/repo
-runner:
-  model: gpt-5.4
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config");
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -927,7 +933,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1);
@@ -952,7 +958,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "old_sha")],
         };
-        let count1 = detect_once(&github1, &db, &config, "bob", &repo_ids, &policies)
+        let count1 = detect_once(&github1, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count1, 1);
@@ -967,7 +973,7 @@ polling:
             username: "bob".into(),
             prs: vec![make_pr(1, "new_sha")],
         };
-        let count2 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count2 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(
@@ -986,7 +992,7 @@ polling:
             .expect("complete canceled");
 
         // Third cycle: now the old job is canceled, new job should be enqueued.
-        let count3 = detect_once(&github2, &db, &config, "bob", &repo_ids, &policies)
+        let count3 = detect_once(&github2, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(
@@ -1002,8 +1008,9 @@ repos:
   allowlist:
     - repo: org/repo
       ignore_prs: [1, 42]
-polling:
-  interval_seconds: 60
+daemon:
+  polling:
+    interval_seconds: 60
 "#,
         )
         .expect("config should parse")
@@ -1020,7 +1027,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 0, "ignored PR should not be enqueued");
@@ -1040,7 +1047,7 @@ polling:
         let policies = config.repo_policies();
         let repo_ids = config.repo_ids();
 
-        let count = detect_once(&github, &db, &config, "bob", &repo_ids, &policies)
+        let count = detect_once(&github, &db, "bob", &repo_ids, &policies)
             .await
             .expect("should succeed");
         assert_eq!(count, 1, "non-ignored PR should be enqueued");

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,20 +75,20 @@ async fn run(cli: Cli) -> reviewq::error::Result<()> {
 
     match cli.command {
         Some(Commands::Status { status, repo }) => {
-            let db = reviewq::db::Database::open(&config.state.sqlite_path)?;
+            let db = reviewq::db::Database::open(&config.daemon.state.sqlite_path)?;
             reviewq::cli::status(&db, status.as_deref(), repo.as_deref())
         }
         Some(Commands::Tail { job_id }) => {
-            let db = reviewq::db::Database::open(&config.state.sqlite_path)?;
-            reviewq::cli::tail(&db, job_id, &config.output.dir)
+            let db = reviewq::db::Database::open(&config.daemon.state.sqlite_path)?;
+            reviewq::cli::tail(&db, job_id, &config.daemon.output.dir)
         }
         Some(Commands::Open { target }) => {
-            let db = reviewq::db::Database::open(&config.state.sqlite_path)?;
+            let db = reviewq::db::Database::open(&config.daemon.state.sqlite_path)?;
             reviewq::cli::open_target(&db, &target)
         }
         Some(Commands::Tui) => {
-            let db = reviewq::db::Database::open(&config.state.sqlite_path)?;
-            reviewq::tui::run(&db, &config.output.dir, &config.logging.dir)
+            let db = reviewq::db::Database::open(&config.daemon.state.sqlite_path)?;
+            reviewq::tui::run(&db, &config.daemon.output.dir, &config.daemon.logging.dir)
         }
         None => run_daemon(config, config_path).await,
     }
@@ -100,30 +100,32 @@ async fn run_daemon(
     config_path: PathBuf,
 ) -> reviewq::error::Result<()> {
     // Initialize logging (hold guard for program lifetime).
-    let _log_guard = reviewq::logging::init(Some(&config.logging.dir));
+    let _log_guard = reviewq::logging::init(Some(&config.daemon.logging.dir));
 
     info!("starting reviewq daemon");
 
     // Single-instance enforcement via PID file.
-    let _pid_file = reviewq::daemon::PidFile::acquire(&config.logging.dir)?;
+    let _pid_file = reviewq::daemon::PidFile::acquire(&config.daemon.logging.dir)?;
 
     // Open database with configured lease duration.
     let db = Arc::new(
-        reviewq::db::Database::open(&config.state.sqlite_path)?
-            .with_lease_minutes(config.execution.lease_minutes),
+        reviewq::db::Database::open(&config.daemon.state.sqlite_path)?
+            .with_lease_minutes(config.daemon.execution.lease_minutes),
     );
 
     // Resolve GitHub token and create API client.
-    let token = reviewq::auth::resolve_token(&config.auth.method, &config.auth.fallback_env)?;
+    let token =
+        reviewq::auth::resolve_token(&config.daemon.auth.method, &config.daemon.auth.fallback_env)?;
     let github = reviewq::github::GitHubApi::new(token);
 
-    // Create the review executor.
-    let default_agent = config.runner.agent.clone().unwrap_or_default();
-    let default_command = default_agent.default_command(config.runner.model.as_deref());
+    // Create the review executor with a built-in fallback command. Each job
+    // carries its own resolved command (see detector), so this default only
+    // applies to legacy or test paths that bypass the detector.
+    let default_command = reviewq::types::AgentKind::default().default_command(None);
     let executor = Arc::new(reviewq::executor::CommandExecutor::new(
         default_command,
-        config.cancel.clone(),
-        config.output.dir.clone(),
+        config.daemon.cancel.clone(),
+        config.daemon.output.dir.clone(),
     ));
 
     // Set up signal handlers for graceful shutdown.
@@ -278,18 +280,33 @@ fn reload_config(
 }
 
 /// Periodically remove expired worktrees.
+///
+/// Uses a single `base_repo` for `git worktree remove` calls, falling back
+/// through `repos.defaults.base_repo_path` → process cwd. This matches the
+/// pre-refactor behavior and intentionally does **not** sweep every distinct
+/// per-repo `base_repo_path`, because `worktree::cleanup` currently scans a
+/// shared `worktree_root` and has no way to pair each reviewq worktree with
+/// its owning repo. Supporting multiple clone locations correctly requires
+/// owner tracking and is tracked as a follow-up (see plan: `cleanup
+/// semantics` in Phase 3).
 async fn worktree_cleanup_loop(mut config_rx: watch::Receiver<Arc<reviewq::config::Config>>) {
     loop {
         let config = config_rx.borrow_and_update().clone();
-        let base_repo =
-            config.execution.base_repo_path.clone().unwrap_or_else(|| {
-                std::env::current_dir().expect("current directory is accessible")
-            });
-        let worktree_root = config.execution.effective_worktree_root();
-        let interval = std::time::Duration::from_secs(config.cleanup.interval_minutes * 60);
+        let base_repo = config
+            .repos
+            .defaults
+            .base_repo_path
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().expect("current directory is accessible"));
+        let worktree_root = config.daemon.execution.effective_worktree_root();
+        let interval = std::time::Duration::from_secs(config.daemon.cleanup.interval_minutes * 60);
 
         tokio::time::sleep(interval).await;
-        match reviewq::worktree::cleanup(&base_repo, &worktree_root, config.cleanup.ttl_minutes) {
+        match reviewq::worktree::cleanup(
+            &base_repo,
+            &worktree_root,
+            config.daemon.cleanup.ttl_minutes,
+        ) {
             Ok(removed) if !removed.is_empty() => {
                 info!(count = removed.len(), "cleaned up expired worktrees");
             }
@@ -307,7 +324,7 @@ mod tests {
     use std::io::Write;
 
     fn minimal_yaml() -> &'static str {
-        "repos:\n  allowlist:\n    - repo: org/repo\npolling:\n  interval_seconds: 60\n"
+        "repos:\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 60\n"
     }
 
     fn write_config(dir: &std::path::Path, yaml: &str) -> PathBuf {
@@ -329,13 +346,13 @@ mod tests {
         // Rewrite with changed polling interval
         write_config(
             dir.path(),
-            "repos:\n  allowlist:\n    - repo: org/repo\npolling:\n  interval_seconds: 120\n",
+            "repos:\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 120\n",
         );
 
         reload_config(&config_path, &config_tx);
 
         let updated = config_rx.borrow().clone();
-        assert_eq!(updated.polling.interval_seconds, 120);
+        assert_eq!(updated.daemon.polling.interval_seconds, 120);
     }
 
     #[test]
@@ -354,7 +371,7 @@ mod tests {
 
         // Old config should be retained
         let current = config_rx.borrow().clone();
-        assert_eq!(current.polling.interval_seconds, 60);
+        assert_eq!(current.daemon.polling.interval_seconds, 60);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -83,17 +83,15 @@ where
     // Semaphore is created once from the initial config; changing
     // max_concurrency requires a restart.
     let initial_config = config_rx.borrow().clone();
-    let semaphore = Arc::new(Semaphore::new(initial_config.execution.max_concurrency));
+    let semaphore = Arc::new(Semaphore::new(
+        initial_config.daemon.execution.max_concurrency,
+    ));
     let mut job_tasks: JoinSet<()> = JoinSet::new();
 
     loop {
         // Re-read config at each iteration so hot-reloaded values take effect.
         let config = config_rx.borrow_and_update().clone();
-        let global_base_repo =
-            config.execution.base_repo_path.clone().unwrap_or_else(|| {
-                std::env::current_dir().expect("current directory is accessible")
-            });
-        let worktree_root = config.execution.effective_worktree_root();
+        let worktree_root = config.daemon.execution.effective_worktree_root();
         let policies = config.repo_policies();
 
         // Drain completed tasks so JoinSet doesn't grow unboundedly.
@@ -145,7 +143,7 @@ where
                 // Wait for either shutdown, wake signal, or poll interval.
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(
-                        config.polling.interval_seconds,
+                        config.daemon.polling.interval_seconds,
                     )) => {}
                     _ = shutdown_rx.changed() => {}
                     _ = wake.notified() => {
@@ -175,12 +173,14 @@ where
             "leased job for execution"
         );
 
-        // Resolve per-repo base path, falling back to global.
+        // Resolve base_repo from the (already-merged) policy. If neither the
+        // entry nor `repos.defaults` set one, fall back to the process cwd so
+        // the `git -C` invocation still has a valid working directory.
         let base_repo = policies
             .iter()
             .find(|p| p.id == job.repo)
             .and_then(|p| p.base_repo_path.clone())
-            .unwrap_or_else(|| global_base_repo.clone());
+            .unwrap_or_else(|| std::env::current_dir().expect("current directory is accessible"));
 
         // Clone Arcs and paths for the spawned task.
         let store = Arc::clone(&store);


### PR DESCRIPTION
## Summary

- Collapse the old 10 top-level sections into two clearly-scoped blocks.
  `daemon:` holds the one-per-install resources (polling, auth,
  execution paths/semaphore, cancel, cleanup, logging, state, output).
  `repos:` holds repo policy with a new `defaults:` template plus the
  existing `allowlist:`, so users can pin common values once instead
  of repeating them per entry. Each field resolves in a
  `RepoEntry -> repos.defaults -> built-in` chain.
- Drop `RunnerConfig` entirely — `agent` / `prompt_template` / `model`
  now live on `RepoDefaults` / `RepoEntry`, eliminating the global-vs-
  per-repo merge logic that had metastasized through `detector.rs`.
  `RepoPolicy` is now fully resolved, so the detector and runner use
  its fields directly without any merge code.
- Move `execution.base_repo_path` to `repos.defaults.base_repo_path`
  (its true home — the old location pretended to be daemon-scoped but
  was actually a per-repo fallback), and delete `RepoEntry.max_concurrency`
  (unimplemented dead field). The runner / cleanup loop now resolve
  base_repo_path through the normal chain.

## Design context

- `#[serde(deny_unknown_fields)]` naturally rejects the old schema, so
  this is a **clean break**. Users must migrate their
  `~/.reviewq/config.yml` by hand; the README config reference has
  been fully rewritten to match.
- Because the executor's command fallback is now `AgentKind::default().
  default_command(None)` (driven by the built-in instead of the removed
  `runner.agent`), existing daemon state DBs should have their
  queued/leased jobs reset before upgrading — otherwise pre-refactor
  jobs with `command IS NULL` will run against the wrong agent. New
  enqueues always materialize `job.command`, so this only affects
  pre-existing rows.
- The detector's old `.or_else(|| config.runner.model.clone())` style
  chains are gone; `repo_policies()` is the single resolution point,
  and both `detector::detect_once` and the runner consume
  already-merged `RepoPolicy` values.
- `Config::diff_summary` is rewritten so `repos.defaults` changes
  surface at field granularity on SIGHUP reloads, matching the daemon
  section-level detail.

## Out of scope (intentional follow-ups)

- **Idempotency key expansion** so `model` / `prompt_template` changes
  force a re-review. Currently the key is still
  `repo/pr/sha/agent_kind`; changes on either field are invisible to
  dedup. This is an independent semantic change and deserves its own
  PR.
- **Worktree cleanup owner tracking** so installs with multiple
  distinct `base_repo_path` values are swept correctly. This PR keeps
  the pre-refactor single-base cleanup (now driven by
  `repos.defaults.base_repo_path -> cwd`) rather than looping over
  every distinct `base_repo_path`, because the current
  `worktree::cleanup()` API cannot pair a reviewq worktree with its
  owning repo. Loop-based cleanup would produce spurious
  \`git worktree remove\` warnings from mis-targeted base repos.
  Tracked as a Phase 3 item in the plan.

## Test plan

- [x] \`make all\` passes locally (245 lib + 4 main + 7 integration +
  14 tui_render tests; 71 hook self-tests).
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Rust reviewer agent: NO CRITICAL / NO HIGH. All 3 MEDIUM findings
  addressed (base_repo_for docstring, cleanup loop comment accuracy,
  diff_summary field-level expansion for \`repos.defaults\`).
- [x] Codex second opinion: LGTM after revert of the multi-base
  cleanup loop and the clean-break clarification on the executor
  command fallback.
- [x] New tests cover:
  - Built-in fallback when neither \`defaults\` nor the entry set a field.
  - \`repos.defaults\` inheritance into bare allowlist entries.
  - Entry overriding a \`defaults\` value.
  - \`base_repo_for\` priority chain (entry > defaults > None).
  - Rejection of the old top-level \`runner:\` key via
    \`deny_unknown_fields\`.
  - Field-level \`diff_summary\` output for \`repos.defaults.agent\`
    and \`repos.defaults.{model, prompt_template}\`.
  - Tilde expansion for \`repos.defaults.base_repo_path\` and
    \`repos.allowlist[].base_repo_path\`.
- [x] Smoke-tested rebuilt binary against the migrated personal
  \`~/.reviewq/config.yml\` (\`reviewq status\` lists queue correctly).

## Upgrade notes

1. Migrate \`~/.reviewq/config.yml\` by hand. Example mapping:
   - \`polling.interval_seconds\` → \`daemon.polling.interval_seconds\`
   - \`auth.{method,fallback_env}\` → \`daemon.auth.*\`
   - \`execution.{worktree_root, max_concurrency, lease_minutes}\` →
     \`daemon.execution.*\`
   - \`execution.base_repo_path\` → \`repos.defaults.base_repo_path\`
   - \`runner.{agent, prompt_template, model}\` → \`repos.defaults.*\`
   - \`cancel\` / \`cleanup\` / \`logging\` / \`state\` / \`output\` →
     \`daemon.*\`
2. If the daemon has queued or leased jobs from a pre-refactor run,
   reset them before starting the new binary (e.g.
   \`sqlite3 ~/.reviewq/state.db 'DELETE FROM jobs WHERE status IN
   (\"queued\",\"leased\",\"running\")'\`). New jobs are unaffected.