### PR TITLE
fix(db): retry_job no longer silent no-ops on CANCELING jobs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -279,6 +279,11 @@ impl JobStore for Database {
 
     fn retry_job(&self, id: i64) -> Result<()> {
         let conn = self.lock_conn();
+        // The CANCELING UI state is a composite — status is non-terminal
+        // (running/queued/leased) AND cancel_requested_at is set. A row
+        // stuck in that state after the runner died mid-cancel must be
+        // recoverable, so the WHERE clause accepts it alongside the
+        // plain Failed / Canceled rows.
         let rows = conn.execute(
             "UPDATE jobs SET status = 'queued',
                     retry_count = 0,
@@ -293,14 +298,17 @@ impl JobStore for Database {
                     worktree_path = NULL,
                     cancel_requested_at = NULL,
                     updated_at = datetime('now')
-             WHERE id = ?1 AND status IN ('failed', 'canceled')",
+             WHERE id = ?1 AND (
+                    status IN ('failed', 'canceled')
+                    OR (status IN ('running', 'queued', 'leased')
+                        AND cancel_requested_at IS NOT NULL)
+             )",
             params![id],
         )?;
         if rows == 0 {
-            tracing::warn!(
-                job_id = id,
-                "retry_job() matched 0 rows — job may not be in a retriable state"
-            );
+            // Surface the no-op so the TUI can flash a clear message
+            // instead of a false-positive "Retry requested".
+            return Err(ReviewqError::Database(rusqlite::Error::QueryReturnedNoRows));
         }
         Ok(())
     }
@@ -880,12 +888,63 @@ mod tests {
     }
 
     #[test]
-    fn retry_noop_on_non_terminal() {
+    fn retry_promotes_canceling_row_back_to_queued() {
+        // A job stuck in the CANCELING composite state (status=running with
+        // cancel_requested_at set) must be retriable: the runner may have
+        // died mid-cancel and the user should be able to recover the row.
+        let db = test_db();
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        let leased = db.lease_next().expect("lease").expect("has job");
+        db.mark_running(leased.id, 4321).expect("mark running");
+        db.request_cancel(job.id).expect("request_cancel");
+
+        db.retry_job(job.id).expect("retry");
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs[0].status, JobStatus::Queued);
+        assert_eq!(jobs[0].retry_count, 0);
+        assert!(jobs[0].cancel_requested_at.is_none());
+        assert!(jobs[0].pid.is_none());
+        assert!(jobs[0].leased_at.is_none());
+        assert!(jobs[0].lease_expires.is_none());
+        assert!(jobs[0].worktree_path.is_none());
+    }
+
+    #[test]
+    fn retry_promotes_queued_cancel_requested_row_back_to_queued() {
+        // Mirror of retry_promotes_canceling_row_back_to_queued but
+        // for the queued-side branch of the CANCELING composite:
+        // request_cancel on a freshly-enqueued job leaves status=queued
+        // with cancel_requested_at set, which the SQL predicate also
+        // covers.
+        let db = test_db();
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        db.request_cancel(job.id).expect("request_cancel");
+
+        db.retry_job(job.id).expect("retry");
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs[0].status, JobStatus::Queued);
+        assert!(jobs[0].cancel_requested_at.is_none());
+    }
+
+    #[test]
+    fn retry_errors_on_non_terminal_without_cancel_request() {
+        // A plain running/queued/leased job with no cancel request is
+        // actively owned by the runner — retry must not silently no-op.
         let db = test_db();
         let job = db.enqueue(sample_job()).expect("enqueue");
 
-        // Job is queued — retry should be a no-op.
-        db.retry_job(job.id).expect("retry");
+        let err = db
+            .retry_job(job.id)
+            .expect_err("retry on non-terminal without cancel request must error");
+        assert!(
+            matches!(
+                err,
+                ReviewqError::Database(rusqlite::Error::QueryReturnedNoRows)
+            ),
+            "unexpected error variant: {err:?}",
+        );
 
         let jobs = db.list_jobs(&JobFilter::default()).expect("list");
         assert_eq!(jobs[0].status, JobStatus::Queued);
@@ -893,16 +952,34 @@ mod tests {
     }
 
     #[test]
-    fn retry_noop_on_succeeded() {
+    fn retry_errors_on_succeeded() {
         let db = test_db();
         let job = db.enqueue(sample_job()).expect("enqueue");
         db.complete(job.id, JobStatus::Succeeded, Some(0))
             .expect("complete");
 
-        db.retry_job(job.id).expect("retry");
+        let err = db
+            .retry_job(job.id)
+            .expect_err("retry on succeeded must error");
+        assert!(matches!(
+            err,
+            ReviewqError::Database(rusqlite::Error::QueryReturnedNoRows)
+        ));
 
         let jobs = db.list_jobs(&JobFilter::default()).expect("list");
         assert_eq!(jobs[0].status, JobStatus::Succeeded);
+    }
+
+    #[test]
+    fn retry_errors_when_job_does_not_exist() {
+        let db = test_db();
+        let err = db
+            .retry_job(9999)
+            .expect_err("retry on missing id must error");
+        assert!(matches!(
+            err,
+            ReviewqError::Database(rusqlite::Error::QueryReturnedNoRows)
+        ));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -308,7 +308,16 @@ impl App {
             }
             Action::RetryJob => {
                 if let Some(job) = self.selected_job() {
-                    if job.status == JobStatus::Failed || job.status == JobStatus::Canceled {
+                    // Retry is allowed for terminal Failed/Canceled rows and
+                    // for the CANCELING composite (non-terminal + cancel
+                    // requested) so a user can recover a row stranded by a
+                    // runner that died mid-cancel. Pure non-terminal rows
+                    // without a cancel request are still actively owned by
+                    // the runner and stay protected.
+                    let retriable = job.status == JobStatus::Failed
+                        || job.status == JobStatus::Canceled
+                        || (!job.status.is_terminal() && job.is_cancel_requested());
+                    if retriable {
                         let job_id = job.id;
                         self.pending_retry = Some(job_id);
                         self.pending_nudge = true;
@@ -670,6 +679,8 @@ mod tests {
     #[test]
     fn retry_job_rejected_for_non_terminal() {
         let (mut app, _tmp) = alive_app();
+        // Pure Running — no cancel request — is actively owned by the
+        // runner and must stay protected from retry at the dispatch layer.
         app.update_jobs(vec![make_job(1, JobStatus::Running)]);
         app.dispatch(Action::RetryJob);
         assert!(app.pending_retry.is_none());
@@ -680,6 +691,37 @@ mod tests {
                 .unwrap()
                 .contains("not in a retriable state")
         );
+    }
+
+    #[test]
+    fn retry_job_allows_canceling_state() {
+        // CANCELING is a composite UI state: status is non-terminal
+        // (running/leased/queued) AND cancel_requested_at is set. The
+        // user must be able to recover such a row via retry when the
+        // runner has died mid-cancel and nothing else will move it.
+        let (mut app, _tmp) = alive_app();
+        let mut job = make_job(1, JobStatus::Running);
+        job.cancel_requested_at = Some(Utc::now());
+        app.update_jobs(vec![job]);
+        app.dispatch(Action::RetryJob);
+        assert_eq!(app.pending_retry, Some(1));
+        assert!(app.pending_nudge);
+        assert!(
+            app.status_message
+                .as_deref()
+                .unwrap()
+                .contains("Retry requested")
+        );
+    }
+
+    #[test]
+    fn retry_job_allows_canceling_state_when_leased() {
+        let (mut app, _tmp) = alive_app();
+        let mut job = make_job(1, JobStatus::Leased);
+        job.cancel_requested_at = Some(Utc::now());
+        app.update_jobs(vec![job]);
+        app.dispatch(Action::RetryJob);
+        assert_eq!(app.pending_retry, Some(1));
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `retry_job` previously matched only `status IN ('failed', 'canceled')` and returned `Ok(())` even when the `UPDATE` affected 0 rows, so jobs stuck in the **CANCELING** composite (`status=running/queued/leased` with `cancel_requested_at` set — typically after a runner died mid-cancel) could not be recovered from the TUI. The user pressed `r`, saw "Retry requested", and nothing happened.
- Widens the `WHERE` clause to accept the CANCELING composite and returns `QueryReturnedNoRows` on `rows_affected == 0` so callers see the no-op instead of a silent `Ok`. Matches the existing convention already used by `mark_running` / two other db.rs sites.
- Loosens the TUI dispatch guard so retry is allowed from CANCELING (`!is_terminal() && is_cancel_requested()`) while keeping pure `Running`/`Queued`/`Leased` protected. Daemon-down guard (Layer 2 dispatch + Layer 3 authoritative re-check from PR #47) is untouched — the two guards are orthogonal.

Fixes #48.

## Test plan

- [x] `make all` green locally (fmt + clippy `-D warnings` + 249 tests + 71 hook self-tests)
- [x] New DB tests:
  - `retry_promotes_canceling_row_back_to_queued` (Running + cancel_requested)
  - `retry_promotes_queued_cancel_requested_row_back_to_queued` (Queued + cancel_requested)
  - `retry_errors_on_non_terminal_without_cancel_request`
  - `retry_errors_on_succeeded`
  - `retry_errors_when_job_does_not_exist`
- [x] New TUI dispatch tests:
  - `retry_job_allows_canceling_state` (Running + cancel_requested)
  - `retry_job_allows_canceling_state_when_leased` (Leased + cancel_requested)
- [x] Existing `retry_job_rejected_for_non_terminal` kept as regression guard: pure Running (no cancel request) still rejected at dispatch layer
- [x] Existing daemon-down regression tests (`dispatch_retry_blocked_when_daemon_status_dead`, etc.) unchanged and still green
- [x] `rust-reviewer` agent: APPROVE, no CRITICAL/HIGH findings