### PR TITLE
fix(cleanup): track worktree ownership for multi base_repo_path installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,14 @@ daemon:
     sigkill_timeout_seconds: 5             # SIGKILL wait after SIGTERM (default: 5)
 
   cleanup:
-    ttl_minutes: 1440                      # Worktree retention period in minutes (default: 1440 = 24h)
+    # Worktree retention period in minutes (default: 1440 = 24h).
+    # The cleanup loop queries the DB for terminal jobs older than this
+    # and `git worktree remove`s each one using its owning repo's
+    # `base_repo_path` (resolved via `repos.defaults` → entry override),
+    # so installs whose `repos.allowlist[]` entries point at different
+    # local clones are all swept correctly. A second "orphan pass"
+    # removes leftover `reviewq-*` directories that have no DB row.
+    ttl_minutes: 1440
     interval_minutes: 30                   # Cleanup check interval in minutes (default: 30)
 
   logging:

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 //! SQLite-backed state management implementing the [`JobStore`] trait.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -495,6 +495,55 @@ impl JobStore for Database {
         )?;
         Ok(exists)
     }
+
+    fn expired_terminal_worktrees(&self, ttl_minutes: u64) -> Result<Vec<(RepoId, PathBuf)>> {
+        let conn = self.lock_conn();
+        // `<=` (not `<`) so that jobs whose `updated_at` falls in the
+        // same second as the cutoff are still treated as expired. SQLite
+        // stores datetimes at one-second resolution, so a strict `<`
+        // would miss jobs that completed within the same second the
+        // cleanup loop runs — surprising for callers that pass
+        // `ttl_minutes = 0` in tests.
+        let cutoff = format!("-{ttl_minutes} minutes");
+        let mut stmt = conn.prepare(
+            "SELECT repo_owner, repo_name, worktree_path
+             FROM jobs
+             WHERE status IN ('succeeded', 'failed', 'canceled')
+               AND worktree_path IS NOT NULL
+               AND updated_at <= datetime('now', ?1)
+             ORDER BY updated_at ASC",
+        )?;
+        let rows = stmt.query_map(params![cutoff], |row| {
+            let owner: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let path_str: String = row.get(2)?;
+            Ok((RepoId::new(owner, name), PathBuf::from(path_str)))
+        })?;
+        let out = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(out)
+    }
+
+    fn known_worktree_paths(&self) -> Result<Vec<PathBuf>> {
+        let conn = self.lock_conn();
+        let mut stmt =
+            conn.prepare("SELECT worktree_path FROM jobs WHERE worktree_path IS NOT NULL")?;
+        let rows = stmt.query_map([], |row| {
+            let path_str: String = row.get(0)?;
+            Ok(PathBuf::from(path_str))
+        })?;
+        let out = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(out)
+    }
+
+    fn clear_worktree_path(&self, path: &Path) -> Result<()> {
+        let conn = self.lock_conn();
+        conn.execute(
+            "UPDATE jobs SET worktree_path = NULL, updated_at = datetime('now')
+             WHERE worktree_path = ?1",
+            params![path.display().to_string()],
+        )?;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -943,5 +992,260 @@ mod tests {
         assert!(jobs[0].pid.is_none());
         assert!(jobs[0].leased_at.is_none());
         assert!(jobs[0].lease_expires.is_none());
+    }
+
+    // -- expired_terminal_worktrees ------------------------------------------
+
+    /// Helper: enqueue + set worktree_path + transition to terminal status
+    /// in one shot, so the jobs have `worktree_path IS NOT NULL` and a
+    /// fresh `updated_at`.
+    fn seed_terminal_job(
+        db: &Database,
+        repo: &RepoId,
+        head_sha: &str,
+        worktree_path: &str,
+        status: JobStatus,
+    ) -> i64 {
+        let new_job = NewJob {
+            repo: repo.clone(),
+            pr_number: 1,
+            head_sha: head_sha.into(),
+            agent_kind: AgentKind::Claude,
+            command: None,
+            prompt_template: None,
+            max_retries: 3,
+        };
+        let job = db.enqueue(new_job).expect("enqueue");
+        db.store_worktree_path(job.id, Path::new(worktree_path))
+            .expect("store worktree_path");
+        let leased = db.lease_next().expect("lease").expect("has job");
+        db.mark_running(leased.id, 1).expect("mark running");
+        db.complete(job.id, status, Some(0)).expect("complete");
+        job.id
+    }
+
+    #[test]
+    fn expired_terminal_worktrees_returns_succeeded_past_ttl() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        seed_terminal_job(&db, &repo, "sha1", "/tmp/wt-1", JobStatus::Succeeded);
+
+        let expired = db
+            .expired_terminal_worktrees(0)
+            .expect("query should succeed");
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].0, repo);
+        assert_eq!(expired[0].1, PathBuf::from("/tmp/wt-1"));
+    }
+
+    #[test]
+    fn expired_terminal_worktrees_includes_failed_and_canceled() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+
+        // succeeded, failed, canceled — all three should be returned.
+        seed_terminal_job(&db, &repo, "sha_succ", "/tmp/wt-succ", JobStatus::Succeeded);
+        seed_terminal_job(&db, &repo, "sha_fail", "/tmp/wt-fail", JobStatus::Failed);
+        seed_terminal_job(&db, &repo, "sha_canc", "/tmp/wt-canc", JobStatus::Canceled);
+
+        let expired = db.expired_terminal_worktrees(0).expect("query");
+        let mut paths: Vec<PathBuf> = expired.into_iter().map(|(_, p)| p).collect();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/tmp/wt-canc"),
+                PathBuf::from("/tmp/wt-fail"),
+                PathBuf::from("/tmp/wt-succ"),
+            ]
+        );
+    }
+
+    #[test]
+    fn expired_terminal_worktrees_excludes_running() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        let job = db
+            .enqueue(NewJob {
+                repo: repo.clone(),
+                pr_number: 7,
+                head_sha: "sha_run".into(),
+                agent_kind: AgentKind::Claude,
+                command: None,
+                prompt_template: None,
+                max_retries: 3,
+            })
+            .expect("enqueue");
+        db.store_worktree_path(job.id, Path::new("/tmp/wt-running"))
+            .expect("store worktree_path");
+        let leased = db.lease_next().expect("lease").expect("has job");
+        db.mark_running(leased.id, 1).expect("mark running");
+        // Do NOT call complete — job stays `running`.
+
+        let expired = db.expired_terminal_worktrees(0).expect("query");
+        assert!(
+            expired.is_empty(),
+            "running jobs must not be returned: {expired:?}"
+        );
+    }
+
+    #[test]
+    fn expired_terminal_worktrees_excludes_queued() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        let job = db
+            .enqueue(NewJob {
+                repo: repo.clone(),
+                pr_number: 11,
+                head_sha: "sha_q".into(),
+                agent_kind: AgentKind::Claude,
+                command: None,
+                prompt_template: None,
+                max_retries: 3,
+            })
+            .expect("enqueue");
+        // Seed a worktree_path even on the queued job so the filter is
+        // *status*, not *worktree_path*.
+        db.store_worktree_path(job.id, Path::new("/tmp/wt-queued"))
+            .expect("store worktree_path");
+
+        let expired = db.expired_terminal_worktrees(0).expect("query");
+        assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn expired_terminal_worktrees_excludes_jobs_without_worktree_path() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        // Complete a job without ever calling store_worktree_path.
+        let job = db
+            .enqueue(NewJob {
+                repo: repo.clone(),
+                pr_number: 99,
+                head_sha: "sha_no_wt".into(),
+                agent_kind: AgentKind::Claude,
+                command: None,
+                prompt_template: None,
+                max_retries: 3,
+            })
+            .expect("enqueue");
+        let leased = db.lease_next().expect("lease").expect("has job");
+        db.mark_running(leased.id, 1).expect("mark running");
+        db.complete(job.id, JobStatus::Succeeded, Some(0))
+            .expect("complete");
+
+        let expired = db.expired_terminal_worktrees(0).expect("query");
+        assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn expired_terminal_worktrees_excludes_jobs_within_ttl() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        seed_terminal_job(&db, &repo, "sha1", "/tmp/wt-recent", JobStatus::Succeeded);
+
+        // The job was updated ~now; asking for "at least 60 minutes old"
+        // should exclude it.
+        let expired = db.expired_terminal_worktrees(60).expect("query");
+        assert!(
+            expired.is_empty(),
+            "recent jobs must not be returned when ttl is 60: {expired:?}"
+        );
+    }
+
+    // -- known_worktree_paths / clear_worktree_path --------------------------
+
+    #[test]
+    fn known_worktree_paths_returns_every_non_null_row() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+
+        // Queued job with a worktree_path (simulating an in-flight row).
+        let queued = db
+            .enqueue(NewJob {
+                repo: repo.clone(),
+                pr_number: 1,
+                head_sha: "sha_q".into(),
+                agent_kind: AgentKind::Claude,
+                command: None,
+                prompt_template: None,
+                max_retries: 3,
+            })
+            .expect("enqueue queued");
+        db.store_worktree_path(queued.id, Path::new("/tmp/wt-q"))
+            .expect("store worktree_path");
+
+        // Terminal job with a worktree_path.
+        seed_terminal_job(&db, &repo, "sha_t", "/tmp/wt-t", JobStatus::Succeeded);
+
+        // Terminal job WITHOUT a worktree_path — must be excluded.
+        let bare = db
+            .enqueue(NewJob {
+                repo: repo.clone(),
+                pr_number: 99,
+                head_sha: "sha_bare".into(),
+                agent_kind: AgentKind::Claude,
+                command: None,
+                prompt_template: None,
+                max_retries: 3,
+            })
+            .expect("enqueue bare");
+        let leased = db.lease_next().expect("lease").expect("has job");
+        db.mark_running(leased.id, 1).expect("mark");
+        // Leave the head job still queued so we don't accidentally lease
+        // the queued row below; just complete the bare one.
+        db.complete(bare.id, JobStatus::Failed, Some(1))
+            .expect("complete");
+
+        let mut paths = db.known_worktree_paths().expect("query");
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("/tmp/wt-q"), PathBuf::from("/tmp/wt-t")]
+        );
+    }
+
+    #[test]
+    fn clear_worktree_path_nulls_matching_row() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        let id = seed_terminal_job(&db, &repo, "sha1", "/tmp/wt-1", JobStatus::Succeeded);
+
+        // Sanity: row has the path we expect.
+        let before = db.known_worktree_paths().expect("query");
+        assert_eq!(before, vec![PathBuf::from("/tmp/wt-1")]);
+
+        db.clear_worktree_path(Path::new("/tmp/wt-1"))
+            .expect("clear");
+
+        // The row still exists, but its worktree_path is now NULL.
+        let after = db.known_worktree_paths().expect("query");
+        assert!(after.is_empty(), "worktree_path should be NULL: {after:?}");
+
+        // Ensure the row itself wasn't deleted.
+        let jobs = db
+            .list_jobs(&JobFilter {
+                status: Some(JobStatus::Succeeded),
+                ..Default::default()
+            })
+            .expect("list");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, id);
+        assert!(jobs[0].worktree_path.is_none());
+    }
+
+    #[test]
+    fn clear_worktree_path_noop_on_missing_path() {
+        let db = test_db();
+        let repo = RepoId::new("owner", "repo");
+        seed_terminal_job(&db, &repo, "sha1", "/tmp/wt-exists", JobStatus::Succeeded);
+
+        // Clearing a path that no row owns must succeed quietly and
+        // leave the existing row untouched.
+        db.clear_worktree_path(Path::new("/tmp/wt-does-not-exist"))
+            .expect("clear noop");
+
+        let paths = db.known_worktree_paths().expect("query");
+        assert_eq!(paths, vec![PathBuf::from("/tmp/wt-exists")]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
+use reviewq::traits::JobStore;
 use tokio::sync::watch;
 use tracing::{error, info, warn};
 
@@ -161,8 +163,9 @@ async fn run_daemon(
 
     // Spawn the worktree cleanup loop.
     let cleanup_config_rx = config_rx.clone();
+    let cleanup_db = Arc::clone(&db);
     let mut cleanup_handle =
-        tokio::spawn(async move { worktree_cleanup_loop(cleanup_config_rx).await });
+        tokio::spawn(async move { worktree_cleanup_loop(cleanup_config_rx, cleanup_db).await });
 
     // Wait for shutdown signal, reload signal, or any task failure/exit.
     // Track which task already resolved to avoid double-await.
@@ -281,39 +284,121 @@ fn reload_config(
 
 /// Periodically remove expired worktrees.
 ///
-/// Uses a single `base_repo` for `git worktree remove` calls, falling back
-/// through `repos.defaults.base_repo_path` → process cwd. This matches the
-/// pre-refactor behavior and intentionally does **not** sweep every distinct
-/// per-repo `base_repo_path`, because `worktree::cleanup` currently scans a
-/// shared `worktree_root` and has no way to pair each reviewq worktree with
-/// its owning repo. Supporting multiple clone locations correctly requires
-/// owner tracking and is tracked as a follow-up (see plan: `cleanup
-/// semantics` in Phase 3).
-async fn worktree_cleanup_loop(mut config_rx: watch::Receiver<Arc<reviewq::config::Config>>) {
+/// DB-driven: queries `JobStore::expired_terminal_worktrees` to get
+/// `(repo, worktree_path)` pairs for every terminal job whose TTL has
+/// elapsed, resolves each `repo` back to its
+/// `RepoPolicy.base_repo_path` via the policy chain, and hands the
+/// list to `worktree::cleanup_by_owner` so `git worktree remove` runs
+/// against the correct base clone.
+///
+/// The set of **currently-known** worktree paths (all statuses, not
+/// just expired terminal) is passed through as `protected` so the
+/// orphan pass inside `cleanup_by_owner` cannot reap a directory
+/// belonging to an in-flight job whose status has not yet transitioned
+/// to terminal.
+///
+/// After each successful tracked removal, the loop clears the
+/// corresponding `jobs.worktree_path` column so the next cycle does
+/// not re-query the same row and reissue a removal against a
+/// directory that is already gone.
+async fn worktree_cleanup_loop(
+    mut config_rx: watch::Receiver<Arc<reviewq::config::Config>>,
+    store: Arc<reviewq::db::Database>,
+) {
     loop {
         let config = config_rx.borrow_and_update().clone();
-        let base_repo = config
+        let worktree_root = config.daemon.execution.effective_worktree_root();
+        let interval = std::time::Duration::from_secs(config.daemon.cleanup.interval_minutes * 60);
+        let ttl_minutes = config.daemon.cleanup.ttl_minutes;
+
+        // Fallback base repo for the orphan pass only. Tracked
+        // worktrees resolve their own base repo per-policy below —
+        // rows for which that resolution fails are skipped, not
+        // silently retargeted at this fallback.
+        let orphan_base_repo = config
             .repos
             .defaults
             .base_repo_path
             .clone()
             .unwrap_or_else(|| std::env::current_dir().expect("current directory is accessible"));
-        let worktree_root = config.daemon.execution.effective_worktree_root();
-        let interval = std::time::Duration::from_secs(config.daemon.cleanup.interval_minutes * 60);
 
         tokio::time::sleep(interval).await;
-        match reviewq::worktree::cleanup(
-            &base_repo,
+
+        // Snapshot every worktree path the DB currently knows about.
+        // The orphan pass inside `cleanup_by_owner` must exclude all
+        // of these so it cannot reap an in-flight job's worktree.
+        //
+        // This snapshot is taken *before* the `expired_terminal_worktrees`
+        // query below, and the two calls run under separate mutex
+        // locks. A job that starts between them will be missing from
+        // both sets — the mtime guard inside `cleanup_by_owner` is the
+        // backstop (a just-created directory cannot satisfy a
+        // sensibly-configured TTL). See `JobStore::known_worktree_paths`
+        // for the full atomicity argument.
+        let mut protected: HashSet<PathBuf> = match store.known_worktree_paths() {
+            Ok(paths) => paths.into_iter().collect(),
+            Err(e) => {
+                warn!(error = %e, "failed to snapshot known worktree paths");
+                continue;
+            }
+        };
+
+        // Pull the expired terminal worktrees and pair each with its
+        // owning base repo. If `base_repo_for` returns `None` (the
+        // repo was dropped from the allowlist between job completion
+        // and cleanup), skip the row and keep it in `protected` so
+        // the orphan pass does not pick it up with a wrong base.
+        let owned: Vec<(PathBuf, PathBuf)> = match store.expired_terminal_worktrees(ttl_minutes) {
+            Ok(rows) => {
+                let mut out = Vec::with_capacity(rows.len());
+                for (repo, wt_path) in rows {
+                    match config.base_repo_for(&repo) {
+                        Some(base) => out.push((base, wt_path)),
+                        None => {
+                            warn!(
+                                repo = %repo,
+                                path = %wt_path.display(),
+                                "base_repo_path not configured for repo; skipping worktree cleanup"
+                            );
+                            protected.insert(wt_path);
+                        }
+                    }
+                }
+                out
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to query expired worktrees");
+                continue;
+            }
+        };
+
+        match reviewq::worktree::cleanup_by_owner(
+            &owned,
             &worktree_root,
-            config.daemon.cleanup.ttl_minutes,
+            ttl_minutes,
+            &orphan_base_repo,
+            &protected,
         ) {
-            Ok(removed) if !removed.is_empty() => {
-                info!(count = removed.len(), "cleaned up expired worktrees");
+            Ok(removed) => {
+                if !removed.is_empty() {
+                    info!(count = removed.len(), "cleaned up expired worktrees");
+                }
+                // NULL out the `worktree_path` column for every path
+                // we successfully removed (tracked and orphan), so
+                // the next cycle's DB query does not return them.
+                for path in &removed {
+                    if let Err(e) = store.clear_worktree_path(path) {
+                        warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "failed to clear worktree_path after removal"
+                        );
+                    }
+                }
             }
             Err(e) => {
                 warn!(error = %e, "worktree cleanup failed");
             }
-            _ => {}
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -127,6 +127,53 @@ pub trait JobStore: Send + Sync {
     /// Returns true when a non-failed, non-canceled job exists for the
     /// (repo, pr_number, agent) triple, regardless of head SHA.
     fn is_pr_reviewed(&self, repo: &RepoId, pr_number: u64, agent: &AgentKind) -> Result<bool>;
+
+    /// Return `(repo, worktree_path)` pairs for terminal jobs whose
+    /// `worktree_path` is set and whose `updated_at` is at least
+    /// `ttl_minutes` old. Excludes jobs still `queued` / `leased` /
+    /// `running`.
+    ///
+    /// Used by the worktree cleanup loop to resolve each expired
+    /// worktree back to its owning repo so `git worktree remove` can
+    /// be called against the correct base clone.
+    fn expired_terminal_worktrees(
+        &self,
+        ttl_minutes: u64,
+    ) -> Result<Vec<(RepoId, std::path::PathBuf)>>;
+
+    /// Return every `worktree_path` currently known to the DB, across
+    /// all job statuses (queued / leased / running / terminal).
+    ///
+    /// Used by the cleanup loop to protect worktrees that belong to
+    /// in-flight jobs from being reaped by the orphan pass before
+    /// their owning row has transitioned to a terminal status.
+    ///
+    /// This is **intentionally a separate call** from
+    /// `expired_terminal_worktrees`: the cleanup loop issues both
+    /// back-to-back under two different `Mutex` locks, which creates
+    /// a theoretical race where a job that starts between the two
+    /// queries is absent from both snapshots. The filesystem mtime
+    /// guard inside `worktree::cleanup_by_owner`'s orphan pass is the
+    /// backstop: a just-created directory cannot yet be old enough
+    /// to trigger TTL expiry unless the operator configures
+    /// `daemon.cleanup.ttl_minutes = 0`, which is not a supported
+    /// production configuration.
+    fn known_worktree_paths(&self) -> Result<Vec<std::path::PathBuf>>;
+
+    /// Clear the `worktree_path` column for any job whose current
+    /// value matches `path`.
+    ///
+    /// Called after a successful `git worktree remove` so the next
+    /// cleanup cycle does not re-query the same row and reissue a
+    /// removal that will fail because the directory is already gone.
+    ///
+    /// In practice each path is unique (the runner names worktrees
+    /// `reviewq-{job_id}`), so this matches at most one row. The SQL
+    /// filter (`WHERE worktree_path = ?1`) is written as an
+    /// unrestricted `UPDATE` so future schema changes that relax
+    /// uniqueness still produce well-defined behavior — all matching
+    /// rows are cleared.
+    fn clear_worktree_path(&self, path: &std::path::Path) -> Result<()>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -8,6 +8,23 @@ use tracing::{info, warn};
 
 use crate::error::{Result, ReviewqError};
 
+/// Build a `git` command whose environment is stripped of the three
+/// variables git uses to locate the current repository. When the
+/// `reviewq` binary (or its test suite) runs inside a `git commit`
+/// pre-commit hook, git exports `GIT_DIR`, `GIT_WORK_TREE`, and
+/// `GIT_INDEX_FILE` into the child process — and those would override
+/// any `current_dir()` we set on a freshly spawned `git` subcommand,
+/// causing the call to operate on the outer repo rather than on the
+/// repo we just pointed at. Scrub them so every git invocation in
+/// this module resolves relative to its `current_dir`.
+fn git() -> Command {
+    let mut cmd = Command::new("git");
+    cmd.env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE");
+    cmd
+}
+
 /// Create a new git worktree for a job.
 ///
 /// Fetches latest refs from origin first (so PR head SHAs are available),
@@ -20,7 +37,7 @@ pub fn create(
     head_sha: &str,
 ) -> Result<PathBuf> {
     // Fetch latest refs so the PR's head SHA is available locally.
-    let fetch_output = Command::new("git")
+    let fetch_output = git()
         .args(["fetch", "origin"])
         .current_dir(base_repo)
         .output()
@@ -38,13 +55,13 @@ pub fn create(
     //   1. Directory exists but git doesn't track it (e.g. DB reset reused job_id)
     //   2. Directory is gone but git metadata still references it (e.g. manual rm)
     // We handle both by always pruning, then force-removing if needed.
-    let _ = Command::new("git")
+    let _ = git()
         .args(["worktree", "prune"])
         .current_dir(base_repo)
         .output();
     if worktree_path.exists() {
         warn!(path = %worktree_path.display(), "worktree path already exists, removing stale entry");
-        let _ = Command::new("git")
+        let _ = git()
             .args(["worktree", "remove", "--force"])
             .arg(&worktree_path)
             .current_dir(base_repo)
@@ -59,7 +76,7 @@ pub fn create(
         }
     }
 
-    let output = Command::new("git")
+    let output = git()
         .args(["worktree", "add", "--detach"])
         .arg(&worktree_path)
         .arg(head_sha)
@@ -83,8 +100,15 @@ pub fn create(
 }
 
 /// Remove a git worktree and prune stale entries.
+///
+/// Uses `git worktree remove --force`. The force flag means uncommitted
+/// changes inside the worktree are silently discarded — which is safe
+/// for reviewq because every worktree is ephemeral scratch space for a
+/// single agent-run job. Returns `Err` when the path is not a
+/// registered worktree under `base_repo`, which callers use to
+/// distinguish "remove succeeded" from "wrong owner".
 pub fn remove(base_repo: &Path, worktree_path: &Path) -> Result<()> {
-    let output = Command::new("git")
+    let output = git()
         .args(["worktree", "remove", "--force"])
         .arg(worktree_path)
         .current_dir(base_repo)
@@ -99,7 +123,7 @@ pub fn remove(base_repo: &Path, worktree_path: &Path) -> Result<()> {
     }
 
     // Prune any stale worktree metadata
-    let _ = Command::new("git")
+    let _ = git()
         .args(["worktree", "prune"])
         .current_dir(base_repo)
         .output();
@@ -108,15 +132,64 @@ pub fn remove(base_repo: &Path, worktree_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Clean up worktrees older than `ttl_minutes`.
+/// Clean up expired worktrees, paired with their owning base repo.
 ///
-/// Scans `worktree_root` for directories matching the `reviewq-*` naming
-/// pattern and removes any whose modification time exceeds the TTL.
-/// Returns the list of paths that were successfully removed.
-pub fn cleanup(base_repo: &Path, worktree_root: &Path, ttl_minutes: u64) -> Result<Vec<PathBuf>> {
+/// Two-pass design:
+///
+/// 1. **Tracked pass.** For each `(base_repo, worktree_path)` in
+///    `owned`, run `git worktree remove --force` against the correct
+///    base repo. The caller (`worktree_cleanup_loop`) gets this list
+///    from the DB via `JobStore::expired_terminal_worktrees`, so the
+///    ownership pairing is always correct. Failures on one entry are
+///    logged and the sweep continues.
+///
+/// 2. **Orphan pass.** Scans `worktree_root` for `reviewq-*`
+///    directories that are NOT in `owned` and NOT in `protected` —
+///    these are leftovers from jobs whose DB row was purged or never
+///    written (crash recovery, manual `DELETE FROM jobs`, etc.).
+///    Orphans older than `ttl_minutes` (by filesystem mtime) are
+///    removed: first by asking git via `orphan_base_repo`, and if
+///    that fails, by falling back to `std::fs::remove_dir_all` plus
+///    a best-effort `git worktree prune`.
+///
+/// The `protected` set MUST include every worktree path the DB
+/// currently knows about across all statuses (queued / leased /
+/// running / terminal-but-not-expired). Without that, the orphan
+/// pass would reap directories belonging to in-flight jobs whose
+/// `worktree_path` has already been written — causing the running
+/// agent process to operate in a deleted directory. Callers can
+/// build this set from `JobStore::known_worktree_paths()`.
+///
+/// Returns every path that was successfully removed (tracked + orphan).
+pub fn cleanup_by_owner(
+    owned: &[(PathBuf, PathBuf)],
+    worktree_root: &Path,
+    ttl_minutes: u64,
+    orphan_base_repo: &Path,
+    protected: &std::collections::HashSet<PathBuf>,
+) -> Result<Vec<PathBuf>> {
+    let mut removed = Vec::new();
+    let mut tracked: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+
+    // --- Tracked pass -------------------------------------------------
+    for (base_repo, wt_path) in owned {
+        tracked.insert(wt_path.clone());
+        match remove(base_repo, wt_path) {
+            Ok(()) => removed.push(wt_path.clone()),
+            Err(e) => {
+                warn!(
+                    path = %wt_path.display(),
+                    base_repo = %base_repo.display(),
+                    error = %e,
+                    "failed to remove tracked worktree (continuing sweep)"
+                );
+            }
+        }
+    }
+
+    // --- Orphan pass --------------------------------------------------
     let ttl = std::time::Duration::from_secs(ttl_minutes * 60);
     let now = SystemTime::now();
-    let mut removed = Vec::new();
 
     let entries = match std::fs::read_dir(worktree_root) {
         Ok(entries) => entries,
@@ -132,10 +205,17 @@ pub fn cleanup(base_repo: &Path, worktree_root: &Path, ttl_minutes: u64) -> Resu
     for entry in entries {
         let entry = entry
             .map_err(|e| ReviewqError::Process(format!("failed to read directory entry: {e}")))?;
-
         let path = entry.path();
 
-        // Only process directories matching our naming convention
+        // Skip both the paths we just swept in the tracked pass and
+        // anything the DB still considers live — that latter category
+        // covers in-flight jobs whose status has not yet transitioned
+        // to terminal, so they aren't in `owned` yet but must not be
+        // reaped out from under the runner.
+        if tracked.contains(&path) || protected.contains(&path) {
+            continue;
+        }
+
         let name = match path.file_name().and_then(|n| n.to_str()) {
             Some(n) if n.starts_with("reviewq-") => n.to_owned(),
             _ => continue,
@@ -146,24 +226,269 @@ pub fn cleanup(base_repo: &Path, worktree_root: &Path, ttl_minutes: u64) -> Resu
         }
 
         let modified = entry.metadata().and_then(|m| m.modified()).unwrap_or(now);
-
         let age = now.duration_since(modified).unwrap_or_default();
+        if age < ttl {
+            continue;
+        }
 
-        if age > ttl {
-            info!(
-                path = %path.display(),
-                name,
-                age_minutes = age.as_secs() / 60,
-                "cleaning up expired worktree"
-            );
-            match remove(base_repo, &path) {
-                Ok(()) => removed.push(path),
-                Err(e) => {
-                    warn!(path = %entry.path().display(), error = %e, "failed to remove worktree")
+        info!(
+            path = %path.display(),
+            name,
+            age_minutes = age.as_secs() / 60,
+            "cleaning up orphan worktree"
+        );
+
+        // Try git first (might work if the orphan happens to be
+        // registered under `orphan_base_repo`); otherwise fall back to
+        // plain filesystem removal plus `git worktree prune`.
+        match remove(orphan_base_repo, &path) {
+            Ok(()) => removed.push(path),
+            Err(git_err) => {
+                warn!(
+                    path = %path.display(),
+                    error = %git_err,
+                    "git worktree remove failed for orphan, falling back to fs::remove_dir_all"
+                );
+                if let Err(fs_err) = std::fs::remove_dir_all(&path) {
+                    warn!(
+                        path = %path.display(),
+                        error = %fs_err,
+                        "fs::remove_dir_all failed for orphan"
+                    );
+                    continue;
                 }
+                let _ = git()
+                    .args(["worktree", "prune"])
+                    .current_dir(orphan_base_repo)
+                    .output();
+                removed.push(path);
             }
         }
     }
 
     Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    /// Initialize a minimal git repo with a single commit so
+    /// `git worktree add --detach <sha>` has something to check out.
+    fn init_repo(path: &Path) {
+        std::fs::create_dir_all(path).expect("create repo dir");
+        run_git(path, &["init", "-q"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "test"]);
+        run_git(path, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(path.join("README.md"), "init\n").expect("write README");
+        run_git(path, &["add", "README.md"]);
+        run_git(path, &["commit", "-q", "-m", "init"]);
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let output = git()
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git spawn");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn head_sha(repo: &Path) -> String {
+        let output = git()
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo)
+            .output()
+            .expect("git rev-parse");
+        String::from_utf8(output.stdout)
+            .expect("utf8")
+            .trim()
+            .to_owned()
+    }
+
+    #[test]
+    fn cleanup_by_owner_removes_tracked_worktrees() {
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let sha = head_sha(&repo);
+        let wt_path = create(&repo, &wt_root, 1, &sha).expect("create worktree");
+        assert!(wt_path.exists());
+
+        let owned = vec![(repo.clone(), wt_path.clone())];
+        let removed =
+            cleanup_by_owner(&owned, &wt_root, 60, &repo, &HashSet::new()).expect("cleanup");
+
+        assert_eq!(removed, vec![wt_path.clone()]);
+        assert!(!wt_path.exists(), "worktree should be gone");
+    }
+
+    #[test]
+    fn cleanup_by_owner_pairs_each_worktree_with_its_own_repo() {
+        // The core motivation: two repos with disjoint base paths, each
+        // owning its own worktree under a shared worktree_root. The
+        // pre-refactor cleanup would have guessed wrong on at least one.
+        let tmp = TempDir::new().expect("tempdir");
+        let repo_a = tmp.path().join("repo_a");
+        let repo_b = tmp.path().join("repo_b");
+        init_repo(&repo_a);
+        init_repo(&repo_b);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let sha_a = head_sha(&repo_a);
+        let sha_b = head_sha(&repo_b);
+        let wt_a = create(&repo_a, &wt_root, 10, &sha_a).expect("create wt_a");
+        let wt_b = create(&repo_b, &wt_root, 20, &sha_b).expect("create wt_b");
+        assert!(wt_a.exists() && wt_b.exists());
+
+        let owned = vec![
+            (repo_a.clone(), wt_a.clone()),
+            (repo_b.clone(), wt_b.clone()),
+        ];
+        let removed =
+            cleanup_by_owner(&owned, &wt_root, 60, &repo_a, &HashSet::new()).expect("cleanup");
+
+        assert_eq!(removed.len(), 2);
+        assert!(removed.contains(&wt_a));
+        assert!(removed.contains(&wt_b));
+        assert!(!wt_a.exists());
+        assert!(!wt_b.exists());
+    }
+
+    #[test]
+    fn cleanup_by_owner_continues_past_one_broken_entry() {
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let sha = head_sha(&repo);
+        let wt_good = create(&repo, &wt_root, 1, &sha).expect("create good wt");
+
+        // Pretend there's a second tracked entry that never existed —
+        // `git worktree remove` will fail on it.
+        let fake = wt_root.join("reviewq-9999");
+        let owned = vec![
+            (repo.clone(), fake.clone()),
+            (repo.clone(), wt_good.clone()),
+        ];
+        let removed =
+            cleanup_by_owner(&owned, &wt_root, 60, &repo, &HashSet::new()).expect("cleanup");
+
+        assert!(removed.contains(&wt_good));
+        assert!(!wt_good.exists());
+    }
+
+    #[test]
+    fn cleanup_by_owner_sweeps_orphan_reviewq_dirs_past_ttl() {
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        // A stray `reviewq-*` directory that was never registered with
+        // git (nor tracked via DB).
+        let orphan = wt_root.join("reviewq-orphan");
+        std::fs::create_dir_all(&orphan).expect("create orphan");
+        std::fs::write(orphan.join("stale.txt"), "old").expect("write stale");
+
+        // ttl=0 treats everything as expired, so the orphan pass kicks
+        // in without having to manipulate mtime.
+        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &HashSet::new()).expect("cleanup");
+
+        assert!(removed.contains(&orphan), "orphan not removed: {removed:?}");
+        assert!(!orphan.exists(), "orphan dir should be gone");
+    }
+
+    #[test]
+    fn cleanup_by_owner_preserves_recent_orphans() {
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let recent = wt_root.join("reviewq-fresh");
+        std::fs::create_dir_all(&recent).expect("create recent");
+
+        // ttl = 60 minutes is plenty; the dir was just created.
+        let removed = cleanup_by_owner(&[], &wt_root, 60, &repo, &HashSet::new()).expect("cleanup");
+
+        assert!(
+            !removed.contains(&recent),
+            "recent orphan must be preserved: {removed:?}"
+        );
+        assert!(recent.exists(), "recent orphan dir should still exist");
+    }
+
+    #[test]
+    fn cleanup_by_owner_ignores_non_reviewq_dirs() {
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let unrelated = wt_root.join("not-ours");
+        std::fs::create_dir_all(&unrelated).expect("create unrelated");
+
+        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &HashSet::new()).expect("cleanup");
+
+        assert!(!removed.contains(&unrelated));
+        assert!(unrelated.exists(), "non-reviewq dir must be untouched");
+    }
+
+    #[test]
+    fn cleanup_by_owner_returns_empty_when_root_missing() {
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("never-created");
+
+        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &HashSet::new()).expect("cleanup");
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn cleanup_by_owner_skips_protected_paths_in_orphan_pass() {
+        // Regression guard for the race where a runner has already
+        // created a `reviewq-*` directory and stored its path in the
+        // DB, but the job is still non-terminal (so it isn't in
+        // `owned`). The caller passes the DB's `known_worktree_paths`
+        // as `protected`, and the orphan pass must honor it even if
+        // the directory looks expired by mtime (ttl=0).
+        let tmp = TempDir::new().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let in_flight = wt_root.join("reviewq-42");
+        std::fs::create_dir_all(&in_flight).expect("create in-flight");
+
+        let mut protected = HashSet::new();
+        protected.insert(in_flight.clone());
+
+        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &protected).expect("cleanup");
+
+        assert!(
+            !removed.contains(&in_flight),
+            "protected path must not be removed: {removed:?}"
+        );
+        assert!(in_flight.exists(), "protected dir must still exist");
+    }
 }


### PR DESCRIPTION
## Summary

- Pivot the worktree cleanup loop from filesystem-mtime scanning to
  DB-driven ownership lookup. The `jobs` table already stores
  `(repo_owner, repo_name, worktree_path)` at creation time, so the
  loop now queries `expired_terminal_worktrees(ttl_minutes)` and
  resolves each row back to its correct \`base_repo_path\` via
  \`Config::base_repo_for\`. Installs whose \`repos.allowlist[]\`
  entries point at different local clones are finally swept without
  \"wrong owner\" \`git worktree remove\` warnings.
- Add a \`protected\` set sourced from
  \`JobStore::known_worktree_paths()\` so the orphan pass inside
  \`cleanup_by_owner\` cannot reap a directory belonging to an
  in-flight job whose \`worktree_path\` has already been written but
  whose status has not yet transitioned to terminal. After each
  successful removal the loop calls
  \`JobStore::clear_worktree_path\` to null the column, so the next
  cycle does not re-query the same row and reissue a removal against
  a directory that is already gone.
- Scrub \`GIT_DIR\` / \`GIT_WORK_TREE\` / \`GIT_INDEX_FILE\` from every
  \`git\` subprocess spawn in \`src/worktree.rs\` (via a new internal
  \`git()\` helper). Without the scrub, any \`reviewq\` binary or
  test binary launched from inside a \`git commit\` pre-commit hook
  would inherit those variables and operate on the outer repo
  instead of the path handed to \`current_dir()\`. This hit the
  test suite immediately on commit (the prek \`make all\` pre-commit
  hook exported \`GIT_DIR\` into \`cargo test\`, and
  \`init_repo\` / \`git worktree add\` under \`TempDir\` silently
  retargeted the outer repo). Production has historically been
  unaffected because reviewq normally runs outside a commit, but
  the fix is free insurance.

## Design notes

- \`worktree::cleanup()\` is fully replaced by
  \`worktree::cleanup_by_owner(owned, worktree_root, ttl, orphan_base_repo, protected)\`
  with a two-pass design. The tracked pass iterates the DB-resolved
  \`(base_repo, worktree_path)\` pairs and continues past individual
  failures. The orphan pass sweeps \`reviewq-*\` directories that are
  in neither \`owned\` nor \`protected\`, subject to the mtime TTL
  guard, and falls back through \`remove(orphan_base_repo, path)\`
  → \`std::fs::remove_dir_all\` → \`git worktree prune\`.
- Rows whose \`repo\` is no longer in the allowlist (the user edited
  config between job completion and cleanup) are **skipped** with a
  \`warn!\` rather than silently retargeted at a fallback base. Their
  paths are folded into \`protected\` so the orphan pass will not pick
  them up with the wrong base either. They remain in the DB until the
  repo is re-added or manually cleared — preserving observability
  over silent leakage.
- The two DB queries (\`known_worktree_paths\` and
  \`expired_terminal_worktrees\`) run under separate mutex locks.
  A job that starts between them would be absent from both snapshots.
  The filesystem mtime guard is the backstop: a freshly created
  directory cannot satisfy a sensibly-configured \`daemon.cleanup.ttl_minutes\`
  (≥ 1 minute). The atomicity argument is spelled out in the
  \`JobStore::known_worktree_paths\` docstring.

## Review history

- rust-reviewer Round 1: NO CRITICAL / 2 HIGH / 3 MEDIUM.
  - HIGH 2: \`orphan_base_repo\` fallback silently masked misconfig
    (unknown repo → CWD). Fixed: skip + add to \`protected\`.
  - HIGH 3: orphan pass could reap in-flight worktrees. Fixed: new
    \`known_worktree_paths\` + \`protected\` parameter.
  - MEDIUM 4, 5, 7 addressed (doc / style / post-cleanup DB update).
- rust-reviewer Round 2: NO CRITICAL / NO HIGH / 3 MEDIUM doc-style
  follow-ups. All addressed (atomicity docstring, uniqueness
  invariant on \`clear_worktree_path\`, \`use std::collections::HashSet\`).
- Codex second opinion (session \`019d7a7b-deab-7821-8d49-6783ac0712d4\`
  resumed from #49): **LGTM**, no blocking findings. Confirmed the
  DB-driven pivot fully resolves the ownership identification problem
  flagged during #49's review.

## Test plan

- [x] \`make all\` passes locally: \`cargo fmt --check\`,
      \`cargo clippy --all-targets -- -D warnings\`,
      \`cargo test\` (280+ tests), and 71 hook self-tests.
- [x] \`GIT_DIR=/tmp/fake cargo test worktree\` passes (confirms the
      env-scrub fix against the original prek-only failure mode).
- [x] \`commit-gate\` passes under prek's \`make all\` pre-commit hook.
- [x] +17 new tests:
  - \`src/db.rs\`: 6 filter-matrix tests for
    \`expired_terminal_worktrees\` (succeeded past TTL, excludes
    running / queued / no-worktree-path / within-TTL, includes
    failed + canceled) plus 3 for
    \`known_worktree_paths\` / \`clear_worktree_path\` round-trip
    and no-op.
  - \`src/worktree.rs\`: 8 tests for \`cleanup_by_owner\` including
    tracked removal, broken-entry continuation, orphan sweep past
    TTL, recent orphan preservation, non-reviewq dir ignored,
    missing root, and the protected-path guard for the in-flight
    race. The standout
    \`cleanup_by_owner_pairs_each_worktree_with_its_own_repo\`
    builds two real \`git init\` repos under a shared
    \`worktree_root\` and verifies both worktrees are correctly
    removed — the exact scenario the pre-refactor cleanup could
    not handle.

Closes #51. Follow-up from #49.