### PR TITLE
feat(tui): show review completion time in queue view

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     cancel_requested_at TEXT,
     created_at    TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at  TEXT,
     UNIQUE(repo_owner, repo_name, pr_number, head_sha, agent_kind)
 );
 "#;
@@ -139,6 +140,36 @@ impl Database {
         if !has_cancel_requested_at {
             conn.execute_batch("ALTER TABLE jobs ADD COLUMN cancel_requested_at TEXT;")?;
         }
+
+        // Add completed_at column if it doesn't exist. Rows that are already
+        // in a terminal state when the migration runs get backfilled from
+        // updated_at, which is the closest proxy we have for the original
+        // completion moment — the row has not been written since it reached
+        // its terminal state in practice.
+        //
+        // The backfill UPDATE is deliberately run *outside* the `if !has`
+        // block. SQLite auto-commits each DDL statement, so if the process
+        // crashes between the ALTER and a once-only UPDATE, the column
+        // would exist on next open and the backfill would never run again,
+        // leaving historical terminal rows stuck at NULL forever. Running
+        // the UPDATE on every open fixes that recovery window — the WHERE
+        // clause restricts it to rows that are both terminal and still
+        // NULL, so on a healthy database it matches zero rows and is a
+        // cheap no-op.
+        let has_completed_at: bool = conn
+            .prepare("PRAGMA table_info(jobs)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .any(|name| name.as_deref() == Ok("completed_at"));
+
+        if !has_completed_at {
+            conn.execute_batch("ALTER TABLE jobs ADD COLUMN completed_at TEXT;")?;
+        }
+        conn.execute(
+            "UPDATE jobs SET completed_at = updated_at
+             WHERE status IN ('succeeded', 'failed', 'canceled')
+               AND completed_at IS NULL",
+            [],
+        )?;
         Ok(())
     }
 
@@ -168,6 +199,7 @@ fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<Job> {
     let stderr_path: Option<String> = row.get("stderr_path")?;
     let worktree_path: Option<String> = row.get("worktree_path")?;
     let cancel_requested_at: Option<String> = row.get("cancel_requested_at")?;
+    let completed_at: Option<String> = row.get("completed_at")?;
 
     Ok(Job {
         id: row.get("id")?,
@@ -195,6 +227,7 @@ fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<Job> {
         cancel_requested_at: cancel_requested_at.map(|s| parse_datetime(&s)),
         created_at: parse_datetime(&created_at),
         updated_at: parse_datetime(&updated_at),
+        completed_at: completed_at.map(|s| parse_datetime(&s)),
     })
 }
 
@@ -256,7 +289,9 @@ impl JobStore for Database {
     fn complete(&self, id: i64, status: JobStatus, exit_code: Option<i32>) -> Result<()> {
         let conn = self.lock_conn();
         let rows = conn.execute(
-            "UPDATE jobs SET status = ?1, exit_code = ?2, updated_at = datetime('now')
+            "UPDATE jobs SET status = ?1, exit_code = ?2,
+                    updated_at = datetime('now'),
+                    completed_at = datetime('now')
              WHERE id = ?3 AND status NOT IN ('succeeded', 'failed', 'canceled')",
             params![status.as_db_str(), exit_code, id],
         )?;
@@ -297,6 +332,7 @@ impl JobStore for Database {
                     stderr_path = NULL,
                     worktree_path = NULL,
                     cancel_requested_at = NULL,
+                    completed_at = NULL,
                     updated_at = datetime('now')
              WHERE id = ?1 AND (
                     status IN ('failed', 'canceled')
@@ -326,7 +362,9 @@ impl JobStore for Database {
     fn cancel_queued_requested(&self) -> Result<Vec<i64>> {
         let conn = self.lock_conn();
         let mut stmt = conn.prepare(
-            "UPDATE jobs SET status = 'canceled', updated_at = datetime('now')
+            "UPDATE jobs SET status = 'canceled',
+                    updated_at = datetime('now'),
+                    completed_at = datetime('now')
              WHERE status = 'queued' AND cancel_requested_at IS NOT NULL
              RETURNING id",
         )?;
@@ -608,6 +646,36 @@ mod tests {
             .expect("list");
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].exit_code, Some(0));
+        assert!(
+            jobs[0].completed_at.is_some(),
+            "complete() must stamp completed_at on terminal transition"
+        );
+    }
+
+    #[test]
+    fn enqueue_leaves_completed_at_none() {
+        // A fresh queued job has not reached a terminal state, so the
+        // completion timestamp must stay NULL until complete() or the
+        // cancel sweep sets it.
+        let db = test_db();
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        assert!(job.completed_at.is_none());
+    }
+
+    #[test]
+    fn cancel_sweep_stamps_completed_at() {
+        let db = test_db();
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        db.request_cancel(job.id).expect("request_cancel");
+        let canceled_ids = db.cancel_queued_requested().expect("sweep");
+        assert_eq!(canceled_ids, vec![job.id]);
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs[0].status, JobStatus::Canceled);
+        assert!(
+            jobs[0].completed_at.is_some(),
+            "cancel_queued_requested() must stamp completed_at"
+        );
     }
 
     #[test]
@@ -760,6 +828,57 @@ mod tests {
     }
 
     #[test]
+    fn migration_backfills_completed_at_on_reopen() {
+        // Regression test for the partial-failure recovery window. SQLite
+        // auto-commits DDL, so a crash between `ALTER TABLE` and the
+        // backfill `UPDATE` would otherwise leave terminal rows stuck at
+        // NULL forever. The fix is to run the backfill unconditionally on
+        // every open, which this test exercises by creating a terminal
+        // row, wiping its completed_at via a raw connection (simulating
+        // the partial-migration state), then reopening the Database and
+        // asserting the row comes back with a stamped value.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).expect("first open");
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        db.complete(job.id, JobStatus::Succeeded, Some(0))
+            .expect("complete");
+
+        // Snapshot the stamped value before dropping it so the backfill
+        // assertion is meaningful.
+        let before = db
+            .list_jobs(&JobFilter::default())
+            .expect("list")
+            .into_iter()
+            .next()
+            .expect("job exists");
+        assert!(before.completed_at.is_some());
+        let updated_at_raw = before.updated_at;
+        drop(db);
+
+        // Simulate the partial-failure state: column exists, row is
+        // terminal, completed_at is NULL.
+        let raw = Connection::open(&db_path).expect("raw open");
+        raw.execute("UPDATE jobs SET completed_at = NULL", [])
+            .expect("wipe completed_at");
+        drop(raw);
+
+        // Reopen → migrate() must backfill from updated_at.
+        let db2 = Database::open(&db_path).expect("reopen");
+        let jobs = db2.list_jobs(&JobFilter::default()).expect("list");
+        assert_eq!(jobs.len(), 1);
+        let after = &jobs[0];
+        assert!(
+            after.completed_at.is_some(),
+            "migrate() must refill completed_at on reopen"
+        );
+        // Backfill source is updated_at, so the two should match to the
+        // second. parse_datetime drops sub-second precision, which is the
+        // same fidelity updated_at is stored at.
+        assert_eq!(after.completed_at.unwrap(), updated_at_raw);
+    }
+
+    #[test]
     fn duplicate_enqueue_rejected() {
         let db = test_db();
         db.enqueue(sample_job()).expect("first enqueue");
@@ -885,6 +1004,10 @@ mod tests {
         assert_eq!(jobs[0].status, JobStatus::Queued);
         assert_eq!(jobs[0].retry_count, 0);
         assert!(jobs[0].cancel_requested_at.is_none());
+        // A retried job is no longer completed — the column must reset
+        // so the TUI renders the em dash placeholder instead of a stale
+        // completion timestamp from the previous run.
+        assert!(jobs[0].completed_at.is_none());
     }
 
     #[test]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -396,6 +396,7 @@ mod tests {
             cancel_requested_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            completed_at: None,
         }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -498,6 +498,7 @@ mod tests {
             cancel_requested_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            completed_at: None,
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -562,6 +562,7 @@ mod tests {
                 cancel_requested_at: None,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                completed_at: None,
             })
             .collect();
         app.update_jobs(jobs);

--- a/src/tui/queue_view.rs
+++ b/src/tui/queue_view.rs
@@ -10,6 +10,11 @@ use super::app::App;
 use super::widgets::{self, SELECTED_STYLE, STATUS_STYLE, TITLE_STYLE};
 use crate::daemon::DaemonHealth;
 
+// Total width of the non-Repo columns, including single-space padding.
+// Repo takes whatever is left over. Sum: ID(6) + PR#(7) + SHA(9) + Agent(8)
+// + Status(9) + Created(18) + Completed(16).
+const FIXED_COL_BUDGET: u16 = 6 + 7 + 9 + 8 + 9 + 18 + 16;
+
 /// Render the queue view.
 pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     // Count jobs by status for the status line.
@@ -67,15 +72,14 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     );
     f.render_widget(Line::styled(status_line, STATUS_STYLE), chunks[1]);
 
-    // 3. Table header (repo width computed after table area is known)
+    // 3. Table header (repo width computed after table area is known).
     // We use chunks[4] width here too; it's available after the layout split.
-    let fixed_cols = 6 + 7 + 9 + 8 + 9 + 18;
     let header_repo_w = (chunks[4].width as usize)
-        .saturating_sub(fixed_cols as usize)
+        .saturating_sub(FIXED_COL_BUDGET as usize)
         .clamp(12, 40);
     let header_spans = vec![Span::styled(
         format!(
-            "  {:<6} {:<rw$} {:<7} {:<9} {:<8} {:<9} {:<18}",
+            "  {:<6} {:<rw$} {:<7} {:<9} {:<8} {:<9} {:<18} {:<16}",
             "ID",
             "Repo",
             "PR#",
@@ -83,6 +87,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
             "Agent",
             "Status",
             "Created",
+            "Completed",
             rw = header_repo_w
         ),
         Style::default()
@@ -110,16 +115,15 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
                 Cell::from(job.agent_kind.to_string()),
                 Cell::from(badge_text).style(badge_style),
                 Cell::from(widgets::format_timestamp(&job.created_at)),
+                Cell::from(widgets::format_timestamp_opt(job.completed_at.as_ref())),
             ])
         })
         .collect();
 
     // Dynamic column widths: fixed columns use Length, Repo gets the remainder.
-    // Fixed total: ID(6) + PR#(7) + SHA(9) + Agent(8) + Status(9) + Created(18) + gaps ≈ 57
-    // Repo gets whatever is left, clamped to a reasonable max.
-    let fixed = 6 + 7 + 9 + 8 + 9 + 18;
+    // Repo gets whatever is left after FIXED_COL_BUDGET, clamped to a reasonable max.
     let table_width = chunks[4].width;
-    let repo_width = table_width.saturating_sub(fixed).clamp(12, 40);
+    let repo_width = table_width.saturating_sub(FIXED_COL_BUDGET).clamp(12, 40);
 
     let widths = [
         Constraint::Length(6),
@@ -129,6 +133,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         Constraint::Length(8),
         Constraint::Length(9),
         Constraint::Length(18),
+        Constraint::Length(16),
     ];
 
     let table = Table::new(rows, widths)

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -85,6 +85,16 @@ pub fn format_timestamp(dt: &DateTime<Utc>) -> String {
     dt.format("%Y-%m-%d %H:%M").to_string()
 }
 
+/// Format an optional timestamp. `None` renders as an em dash so the
+/// queue view's Completed column has a visible placeholder for jobs
+/// that have not yet reached a terminal state.
+pub fn format_timestamp_opt(dt: Option<&DateTime<Utc>>) -> String {
+    match dt {
+        Some(d) => format_timestamp(d),
+        None => "—".to_owned(),
+    }
+}
+
 /// Truncate a SHA to 7 characters for display.
 pub fn short_sha(sha: &str) -> &str {
     if sha.len() > 7 { &sha[..7] } else { sha }

--- a/src/types.rs
+++ b/src/types.rs
@@ -378,6 +378,11 @@ pub struct Job {
     pub cancel_requested_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Wall-clock time at which the job first reached a terminal state
+    /// (Succeeded / Failed / Canceled). `None` while the job is queued,
+    /// leased, or running. Surfaced in the TUI queue view so users can
+    /// see when each review actually finished.
+    pub completed_at: Option<DateTime<Utc>>,
 }
 
 impl Job {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -145,6 +145,7 @@ fn make_test_job(id: i64, command: Option<&str>) -> reviewq::types::Job {
         cancel_requested_at: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        completed_at: None,
     }
 }
 

--- a/tests/tui_render.rs
+++ b/tests/tui_render.rs
@@ -88,6 +88,7 @@ fn make_job(id: i64, status: JobStatus, owner: &str, repo: &str) -> Job {
         cancel_requested_at: None,
         created_at: fixed_time(),
         updated_at: fixed_time(),
+        completed_at: None,
     }
 }
 
@@ -214,6 +215,40 @@ fn queue_renders_status_summary_counts_by_state() {
     assert_buffer_contains(&term, "Running: 1");
     assert_buffer_contains(&term, "Done: 1");
     assert_buffer_contains(&term, "Failed: 1");
+}
+
+#[test]
+fn queue_shows_completed_header_and_em_dash_for_unfinished_jobs() {
+    // The queue table should expose a "Completed" column header so users
+    // can see at a glance when a review finished. Non-terminal jobs have
+    // no completion time, so the cell must render an em dash placeholder
+    // instead of a blank or "N/A" string. This guards both the header
+    // label and the placeholder rendering in one pass.
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    app.update_jobs(vec![make_job(1, JobStatus::Queued, "o", "r")]);
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "Completed");
+    assert_buffer_contains(&term, "—");
+}
+
+#[test]
+fn queue_renders_completed_timestamp_for_succeeded_job() {
+    // A terminal (Succeeded) job with a concrete completion time must
+    // render the formatted "YYYY-MM-DD HH:MM" value in the Completed
+    // column, not the em dash placeholder. This catches the regression
+    // where the column is wired up but the timestamp is silently dropped.
+    let mut term = test_terminal(120, 24);
+    let (mut app, _tmp) = make_app();
+    let completion = DateTime::parse_from_rfc3339("2026-02-03T04:05:06Z")
+        .expect("valid rfc3339 literal")
+        .with_timezone(&Utc);
+    app.update_jobs(vec![Job {
+        completed_at: Some(completion),
+        ..make_job(1, JobStatus::Succeeded, "o", "r")
+    }]);
+    draw_queue(&mut term, &mut app);
+    assert_buffer_contains(&term, "2026-02-03 04:05");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a `completed_at` column to the `jobs` table, stamped on every transition into a terminal state (Succeeded / Failed / Canceled), and surface it as a new "Completed" column in the TUI queue view so users can see when each review actually finished, not just when it was queued.
- `retry_job` resets the column back to NULL — a retried job is no longer completed, and leaving a stale timestamp would contradict `status='queued'`.
- Migration is crash-safe: the backfill `UPDATE` that fills `completed_at` from `updated_at` for historical terminal rows runs unconditionally on every open. SQLite auto-commits DDL, so a once-only UPDATE guarded by `if !has_column` could be skipped forever after a partial-failure between the ALTER and the UPDATE. Running it unconditionally — with `WHERE status IN (...) AND completed_at IS NULL` — means a healthy database matches zero rows, and a partial-failure state is self-healed on the next open.

## Test plan

- [x] `make all` — fmt + clippy `-D warnings` + 253 lib + 4 + 7 + 16 integration tests + 71 hook self-tests, all green
- [x] New db-layer tests: `enqueue_leaves_completed_at_none`, `cancel_sweep_stamps_completed_at`, updated `complete_job`, retry test asserts `completed_at.is_none()`
- [x] New migration regression test `migration_backfills_completed_at_on_reopen` — creates a terminal row, wipes `completed_at` via raw rusqlite connection to simulate the partial-failure state, reopens `Database`, and asserts the column is refilled from `updated_at`
- [x] New TUI render tests: `queue_shows_completed_header_and_em_dash_for_unfinished_jobs`, `queue_renders_completed_timestamp_for_succeeded_job` (TestBackend)
- [ ] Optional manual verification: run daemon against a real DB, push a job through to Succeeded, confirm the Completed column shows the finish time in the queue view