### PR TITLE
fix(config): make base_repo_path mandatory and validated at startup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -477,6 +477,23 @@ impl Config {
             }
         }
 
+        // Every allowlisted repo must resolve a base_repo_path — either
+        // directly on the entry or inherited from repos.defaults. Without
+        // this, the runner and cleanup loop fall back to the process cwd,
+        // which makes reviewq's behavior silently depend on where the
+        // daemon was started. The filesystem-level check (path exists,
+        // path is a directory) lives in `validate_paths`, which is called
+        // separately by daemon / TUI startup after `expand_paths`.
+        let defaults_base = self.repos.defaults.base_repo_path.is_some();
+        for entry in &self.repos.allowlist {
+            if entry.base_repo_path.is_none() && !defaults_base {
+                return Err(ReviewqError::Config(format!(
+                    "base_repo_path is required for repo '{}': set repos.defaults.base_repo_path or repos.allowlist[].base_repo_path",
+                    entry.repo
+                )));
+            }
+        }
+
         // Validate model names (defaults and per-repo).
         if let Some(ref m) = self.repos.defaults.model
             && !is_valid_model_name(m)
@@ -502,6 +519,42 @@ impl Config {
             ));
         }
 
+        Ok(())
+    }
+
+    /// Verify that every resolved `base_repo_path` exists on disk and is a
+    /// directory. Must be called **after** [`expand_paths`] so tilde paths
+    /// are resolved. Not called from [`from_yaml`] — unit tests that build
+    /// configs from in-memory YAML do not need real directories.
+    ///
+    /// This is called only from the daemon and TUI startup paths. Read-only
+    /// subcommands (`status` / `tail` / `open`) skip this check so a broken
+    /// filesystem path does not stop the user from inspecting job history.
+    pub fn validate_paths(&self) -> Result<()> {
+        for policy in self.repo_policies() {
+            let Some(path) = policy.base_repo_path.as_ref() else {
+                // Structurally invalid — validate() should have caught this.
+                // Guard defensively rather than panicking.
+                return Err(ReviewqError::Config(format!(
+                    "base_repo_path is required for repo '{}'",
+                    policy.id
+                )));
+            };
+            if !path.exists() {
+                return Err(ReviewqError::Config(format!(
+                    "base_repo_path for repo '{}' does not exist: {}",
+                    policy.id,
+                    path.display()
+                )));
+            }
+            if !path.is_dir() {
+                return Err(ReviewqError::Config(format!(
+                    "base_repo_path for repo '{}' is not a directory: {}",
+                    policy.id,
+                    path.display()
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -811,6 +864,8 @@ mod tests {
     fn parse_minimal_config() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: owner/repo
 "#;
@@ -827,6 +882,8 @@ repos:
     fn parse_per_repo_overrides() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo1
       skip_self_authored: false
@@ -870,6 +927,7 @@ daemon:
 repos:
   defaults:
     agent: codex
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo1
     - repo: org/repo2
@@ -887,8 +945,13 @@ repos:
 
     #[test]
     fn resolve_falls_back_to_builtin_when_nothing_set() {
+        // `base_repo_path` is required, so set a minimal defaults value.
+        // Every *other* field (agent, model, prompt, skip flags, ignore)
+        // falls back to the built-in defaults.
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#;
@@ -903,7 +966,7 @@ repos:
         assert_eq!(p.agent, AgentKind::Claude);
         assert!(p.prompt_template.is_none());
         assert!(p.model.is_none());
-        assert!(p.base_repo_path.is_none());
+        assert_eq!(p.base_repo_path, Some(PathBuf::from("/tmp/fake")));
         assert!(p.ignore_prs.is_empty());
     }
 
@@ -971,6 +1034,8 @@ repos:
     fn builtin_skip_self_authored_is_true() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#;
@@ -982,6 +1047,8 @@ repos:
     fn builtin_review_on_push_is_true() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#;
@@ -993,6 +1060,8 @@ repos:
     fn entry_can_disable_review_on_push() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       review_on_push: false
@@ -1005,6 +1074,8 @@ repos:
     fn repo_ids_extracts_ids() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo1
     - repo: org/repo2
@@ -1040,14 +1111,25 @@ repos:
     }
 
     #[test]
-    fn base_repo_for_returns_none_when_nothing_set() {
+    fn base_repo_for_returns_none_for_unknown_repo() {
+        // The original version of this test documented the "nothing set"
+        // path that returned `None`. With base_repo_path now mandatory,
+        // that state is structurally invalid, so instead assert that an
+        // *unknown* repo id still returns `None` even when the allowlist
+        // has resolved paths.
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#;
         let config = Config::from_yaml(yaml).expect("parse");
-        assert_eq!(config.base_repo_for(&RepoId::new("org", "repo")), None);
+        assert_eq!(
+            config.base_repo_for(&RepoId::new("org", "repo")),
+            Some(PathBuf::from("/tmp/fake"))
+        );
+        assert_eq!(config.base_repo_for(&RepoId::new("org", "unknown")), None);
     }
 
     // -- validation -----------------------------------------------------
@@ -1095,7 +1177,7 @@ repos:
             "a_b-c.d:e",
         ] {
             let yaml = format!(
-                "repos:\n  defaults:\n    model: {name}\n  allowlist:\n    - repo: org/repo\n"
+                "repos:\n  defaults:\n    base_repo_path: /tmp/fake\n    model: {name}\n  allowlist:\n    - repo: org/repo\n"
             );
             Config::from_yaml(&yaml)
                 .unwrap_or_else(|e| panic!("model '{name}' should be valid: {e}"));
@@ -1106,7 +1188,7 @@ repos:
     fn invalid_defaults_model_rejected() {
         for name in ["model name", "model;rm", "$(echo hi)", "mod\"el", ""] {
             let yaml = format!(
-                "repos:\n  defaults:\n    model: \"{name}\"\n  allowlist:\n    - repo: org/repo\n"
+                "repos:\n  defaults:\n    base_repo_path: /tmp/fake\n    model: \"{name}\"\n  allowlist:\n    - repo: org/repo\n"
             );
             assert!(
                 Config::from_yaml(&yaml).is_err(),
@@ -1119,6 +1201,8 @@ repos:
     fn invalid_per_repo_model_rejected() {
         let yaml = r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       model: "bad model"
@@ -1149,6 +1233,8 @@ daemon:
   polling:
     interval_seconds: 0
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#;
@@ -1165,6 +1251,8 @@ daemon:
   polling:
     interval_seconds: 60
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#;
@@ -1181,6 +1269,8 @@ daemon:
   polling:
     interval_seconds: 60
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1192,6 +1282,8 @@ daemon:
   polling:
     interval_seconds: 120
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1212,6 +1304,8 @@ daemon:
   execution:
     max_concurrency: 5
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1223,6 +1317,8 @@ daemon:
   execution:
     max_concurrency: 20
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1241,6 +1337,8 @@ repos:
         let old = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo1
 "#,
@@ -1249,6 +1347,8 @@ repos:
         let new = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo2
 "#,
@@ -1263,6 +1363,8 @@ repos:
         let old = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       review_on_push: true
@@ -1272,6 +1374,8 @@ repos:
         let new = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       review_on_push: false
@@ -1289,6 +1393,7 @@ repos:
 repos:
   defaults:
     agent: claude
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1299,6 +1404,7 @@ repos:
 repos:
   defaults:
     agent: codex
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1323,6 +1429,7 @@ repos:
   defaults:
     model: gpt-5.3-codex
     prompt_template: "old"
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1334,6 +1441,7 @@ repos:
   defaults:
     model: gpt-5.4
     prompt_template: "new"
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 "#,
@@ -1357,6 +1465,8 @@ repos:
         let old = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       model: gpt-5.4
@@ -1366,6 +1476,8 @@ repos:
         let new = Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       model: gpt-5.3-codex
@@ -1377,6 +1489,131 @@ repos:
             changes
                 .iter()
                 .any(|c| c.contains("per-repo settings changed"))
+        );
+    }
+
+    // -- base_repo_path mandatory validation ----------------------------
+
+    #[test]
+    fn validate_rejects_missing_base_repo_path() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("base_repo_path"),
+            "error should mention base_repo_path, got: {msg}"
+        );
+        assert!(
+            msg.contains("org/repo"),
+            "error should name the offending repo, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_defaults_only_base_repo_path() {
+        let yaml = r#"
+repos:
+  defaults:
+    base_repo_path: /tmp/fake
+  allowlist:
+    - repo: org/repo
+"#;
+        let config = Config::from_yaml(yaml).expect("should parse");
+        assert_eq!(
+            config.repos.defaults.base_repo_path,
+            Some(PathBuf::from("/tmp/fake"))
+        );
+    }
+
+    #[test]
+    fn validate_accepts_per_entry_base_repo_path() {
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo
+      base_repo_path: /tmp/entry
+"#;
+        let config = Config::from_yaml(yaml).expect("should parse");
+        assert_eq!(
+            config.repos.allowlist[0].base_repo_path,
+            Some(PathBuf::from("/tmp/entry"))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_missing_base_repo_path_for_one_of_many() {
+        // Defaults are empty. repo-a supplies its own base_repo_path,
+        // but repo-b has nothing to inherit, so validation must point
+        // at repo-b specifically rather than accepting the allowlist
+        // because "at least one entry has a path set."
+        let yaml = r#"
+repos:
+  allowlist:
+    - repo: org/repo-a
+      base_repo_path: /tmp/a
+    - repo: org/repo-b
+"#;
+        let err = Config::from_yaml(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("org/repo-b"),
+            "error should name repo-b specifically, got: {msg}"
+        );
+    }
+
+    // -- validate_paths (filesystem checks) -----------------------------
+
+    #[test]
+    fn validate_paths_accepts_existing_directory() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let yaml = format!(
+            "repos:\n  defaults:\n    base_repo_path: {}\n  allowlist:\n    - repo: org/repo\n",
+            tmp.path().display()
+        );
+        let config = Config::from_yaml(&yaml).expect("parse");
+        config.validate_paths().expect("should accept existing dir");
+    }
+
+    #[test]
+    fn validate_paths_rejects_nonexistent_path() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let missing = tmp.path().join("nowhere");
+        let yaml = format!(
+            "repos:\n  defaults:\n    base_repo_path: {}\n  allowlist:\n    - repo: org/repo\n",
+            missing.display()
+        );
+        let config = Config::from_yaml(&yaml).expect("parse");
+        let err = config.validate_paths().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not exist") || msg.contains("not a directory"),
+            "error should explain the path problem, got: {msg}"
+        );
+        assert!(
+            msg.contains("org/repo"),
+            "error should name the repo, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_paths_rejects_regular_file() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let file = tmp.path().join("not-a-dir.txt");
+        std::fs::write(&file, b"hello").expect("write file");
+        let yaml = format!(
+            "repos:\n  defaults:\n    base_repo_path: {}\n  allowlist:\n    - repo: org/repo\n",
+            file.display()
+        );
+        let config = Config::from_yaml(&yaml).expect("parse");
+        let err = config.validate_paths().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not a directory") || msg.contains("does not exist"),
+            "error should explain the is_dir check, got: {msg}"
         );
     }
 

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -232,6 +232,8 @@ mod tests {
         Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 daemon:
@@ -246,6 +248,8 @@ daemon:
         Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       skip_self_authored: false
@@ -364,6 +368,7 @@ daemon:
 repos:
   defaults:
     agent: claude
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       agent: codex
@@ -402,6 +407,7 @@ daemon:
 repos:
   defaults:
     agent: codex
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 daemon:
@@ -439,6 +445,7 @@ daemon:
 repos:
   defaults:
     prompt_template: "global-prompt"
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       prompt_template: "per-repo-prompt"
@@ -472,6 +479,7 @@ daemon:
 repos:
   defaults:
     prompt_template: "global-prompt"
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 daemon:
@@ -584,6 +592,8 @@ daemon:
         Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       skip_self_authored: false
@@ -627,6 +637,8 @@ daemon:
         Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       review_on_push: false
@@ -853,6 +865,7 @@ daemon:
 repos:
   defaults:
     model: gpt-5.4
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       model: gpt-5.3-codex
@@ -894,6 +907,7 @@ daemon:
 repos:
   defaults:
     model: gpt-5.4
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
 daemon:
@@ -1005,6 +1019,8 @@ daemon:
         Config::from_yaml(
             r#"
 repos:
+  defaults:
+    base_repo_path: /tmp/fake
   allowlist:
     - repo: org/repo
       ignore_prs: [1, 42]

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,10 +89,21 @@ async fn run(cli: Cli) -> reviewq::error::Result<()> {
             reviewq::cli::open_target(&db, &target)
         }
         Some(Commands::Tui) => {
+            // TUI needs a runnable worktree setup at its back so
+            // `x` (cancel) / `r` (retry) keystrokes don't later
+            // explode inside the runner. Read-only subcommands
+            // (`status` / `tail` / `open`) skip this check so a
+            // broken filesystem path doesn't block post-mortem.
+            config.validate_paths()?;
             let db = reviewq::db::Database::open(&config.daemon.state.sqlite_path)?;
             reviewq::tui::run(&db, &config.daemon.output.dir, &config.daemon.logging.dir)
         }
-        None => run_daemon(config, config_path).await,
+        None => {
+            // Same rationale as the TUI branch: fail fast before
+            // the daemon even begins if `base_repo_path` is wrong.
+            config.validate_paths()?;
+            run_daemon(config, config_path).await
+        }
     }
 }
 
@@ -259,6 +270,18 @@ fn reload_config(
     };
     new_config.expand_paths();
 
+    // Filesystem check for every resolved `base_repo_path`. Missing
+    // or non-directory paths are treated like any other reload error:
+    // we log and keep the old config so the daemon does not die
+    // because the user temporarily moved a clone aside. `warn!`
+    // (not `error!`) because this is an explicitly *recoverable*
+    // condition — the operator may already be fixing it and should
+    // not be paged.
+    if let Err(e) = new_config.validate_paths() {
+        warn!(error = %e, "config reload: validate_paths failed, keeping previous config");
+        return;
+    }
+
     let old_config = config_tx.borrow().clone();
 
     let changes = reviewq::config::Config::diff_summary(&old_config, &new_config);
@@ -320,21 +343,25 @@ fn cleanup_once(
     let worktree_root = config.daemon.execution.effective_worktree_root();
     let ttl_minutes = config.daemon.cleanup.ttl_minutes;
 
-    // Fallback base repo for the orphan pass only. Tracked
-    // worktrees resolve their own base repo per-policy below —
-    // rows for which that resolution fails are skipped, not
-    // silently retargeted at this fallback. The CWD lookup is
-    // a `?` rather than an `expect()` because `cleanup_once`
-    // runs inside `spawn_blocking`, and a panic there would
-    // surface as a `JoinError` which is harder to debug than
-    // a normal `Err` log line.
-    let orphan_base_repo = match config.repos.defaults.base_repo_path.clone() {
-        Some(p) => p,
-        None => std::env::current_dir().map_err(|e| {
-            reviewq::error::ReviewqError::Process(format!(
-                "failed to read current directory for orphan-pass fallback: {e}"
-            ))
-        })?,
+    // Every distinct `base_repo_path` resolved by the policy chain.
+    // `cleanup_by_owner`'s orphan pass runs `git worktree prune`
+    // against each one after reaping stale directories, so every
+    // allowlisted install keeps its `.git/worktrees/` bookkeeping
+    // clean — not just the repo that happened to be picked
+    // arbitrarily (the pre-refactor behavior). Duplicates are
+    // deduplicated here; the policy chain guarantees every entry
+    // has `Some(path)` thanks to `Config::validate`.
+    let orphan_base_repos: Vec<PathBuf> = {
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut out: Vec<PathBuf> = Vec::new();
+        for policy in config.repo_policies() {
+            if let Some(path) = policy.base_repo_path
+                && seen.insert(path.clone())
+            {
+                out.push(path);
+            }
+        }
+        out
     };
 
     // Snapshot every worktree path the DB currently knows about.
@@ -374,7 +401,7 @@ fn cleanup_once(
         &owned,
         &worktree_root,
         ttl_minutes,
-        &orphan_base_repo,
+        &orphan_base_repos,
         &protected,
     )?;
 
@@ -445,7 +472,12 @@ mod tests {
     use std::io::Write;
 
     fn minimal_yaml() -> &'static str {
-        "repos:\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 60\n"
+        // `/tmp` is the simplest always-existent, always-a-directory
+        // path that is acceptable to `validate_paths`. Tests that
+        // exercise `reload_config` run through that check too, so a
+        // bogus `/tmp/fake` would be rejected and the "old config
+        // retained" assertions would pass spuriously.
+        "repos:\n  defaults:\n    base_repo_path: /tmp\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 60\n"
     }
 
     fn write_config(dir: &std::path::Path, yaml: &str) -> PathBuf {
@@ -467,7 +499,7 @@ mod tests {
         // Rewrite with changed polling interval
         write_config(
             dir.path(),
-            "repos:\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 120\n",
+            "repos:\n  defaults:\n    base_repo_path: /tmp\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 120\n",
         );
 
         reload_config(&config_path, &config_tx);
@@ -512,6 +544,36 @@ mod tests {
         // Old config should be retained
         let current = config_rx.borrow().clone();
         assert_eq!(current.repos.allowlist.len(), 1);
+    }
+
+    #[test]
+    fn reload_config_path_missing_keeps_old_config() {
+        // Regression guard for the graceful-degradation rule added
+        // alongside the `validate_paths` mandatory-startup check: when
+        // a hot reload produces a structurally-valid config whose
+        // `base_repo_path` has been deleted on disk, the daemon keeps
+        // running on the old config rather than dying.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = write_config(dir.path(), minimal_yaml());
+
+        let mut initial = reviewq::config::Config::load(&config_path).expect("load");
+        initial.expand_paths();
+        let (config_tx, config_rx) = watch::channel(Arc::new(initial));
+
+        // Overwrite with a config whose base_repo_path points at a
+        // path that definitely does not exist. validate() accepts it
+        // (structurally valid), validate_paths() must reject it, and
+        // reload_config must keep the old config.
+        let bad_yaml = "repos:\n  defaults:\n    base_repo_path: /tmp/reviewq-reload-test-nowhere-aaa\n  allowlist:\n    - repo: org/repo\ndaemon:\n  polling:\n    interval_seconds: 120\n";
+        write_config(dir.path(), bad_yaml);
+
+        reload_config(&config_path, &config_tx);
+
+        let current = config_rx.borrow().clone();
+        assert_eq!(
+            current.daemon.polling.interval_seconds, 60,
+            "old config must be retained after validate_paths failure"
+        );
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3,7 +3,7 @@
 pub mod cancel;
 pub mod process;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use nix::sys::signal;
@@ -12,7 +12,7 @@ use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, oneshot, watch};
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
-use crate::config::Config;
+use crate::config::{Config, RepoPolicy};
 use crate::error::Result;
 use crate::traits::{Clock, JobStore, ReviewExecutor};
 use crate::types::{Job, JobFilter, JobStatus};
@@ -173,14 +173,16 @@ where
             "leased job for execution"
         );
 
-        // Resolve base_repo from the (already-merged) policy. If neither the
-        // entry nor `repos.defaults` set one, fall back to the process cwd so
-        // the `git -C` invocation still has a valid working directory.
-        let base_repo = policies
-            .iter()
-            .find(|p| p.id == job.repo)
-            .and_then(|p| p.base_repo_path.clone())
-            .unwrap_or_else(|| std::env::current_dir().expect("current directory is accessible"));
+        // Resolve base_repo from the (already-merged) policy. If the repo
+        // was removed from the allowlist by a hot reload between enqueue
+        // and lease, fail the job cleanly rather than panicking. Startup
+        // validation (`Config::validate` + `Config::validate_paths`) is
+        // responsible for rejecting a missing / non-existent path at load
+        // time, so the only way through to this helper is the reload race.
+        let Some(base_repo) = resolve_base_repo_or_fail_job(&*store, &policies, &job) else {
+            drop(permit);
+            continue;
+        };
 
         // Clone Arcs and paths for the spawned task.
         let store = Arc::clone(&store);
@@ -202,6 +204,56 @@ where
     info!("all in-flight jobs completed");
 
     Ok(())
+}
+
+/// Resolve the `base_repo_path` for a leased job, or fail the job cleanly
+/// if the policy cannot be found.
+///
+/// At steady state this always returns `Some(path)` — the validation in
+/// [`Config::validate`] guarantees every allowlisted repo has a
+/// resolvable `base_repo_path`. The failure branch exists for the
+/// *hot-reload race*: between the time a job is queued and the time the
+/// runner leases it, the user can remove the repo from the allowlist via
+/// SIGHUP. When that happens, the leased job has no place to run, and
+/// the cleanest outcome is to mark it `Failed` with an explanatory log
+/// line rather than panic or fall back to `current_dir()` (the old
+/// behavior, which made reviewq's execution silently depend on *where
+/// the daemon was started*).
+///
+/// Returns:
+/// - `Some(path)` — policy found; the caller proceeds with execution.
+/// - `None` — policy missing or has no `base_repo_path`; the job has been
+///   marked `Failed` in the store, the caller must drop its permit and
+///   skip to the next iteration.
+///
+/// Side effects on the `None` branch: one `error!` log line and one
+/// `store.complete(job.id, Failed, None)` call. `store.complete`
+/// failures are logged but not propagated — the caller cannot recover
+/// from a broken store here and must keep the runner loop alive.
+fn resolve_base_repo_or_fail_job<S: JobStore>(
+    store: &S,
+    policies: &[RepoPolicy],
+    job: &Job,
+) -> Option<PathBuf> {
+    let policy = policies.iter().find(|p| p.id == job.repo);
+    match policy.and_then(|p| p.base_repo_path.clone()) {
+        Some(path) => Some(path),
+        None => {
+            error!(
+                job_id = job.id,
+                repo = %job.repo,
+                "repo removed from allowlist after job was leased; marking job Failed"
+            );
+            if let Err(e) = store.complete(job.id, JobStatus::Failed, None) {
+                error!(
+                    job_id = job.id,
+                    error = %e,
+                    "failed to mark job Failed after allowlist removal; runner loop will continue but the job will remain in Leased state until daemon restart or manual DB intervention"
+                );
+            }
+            None
+        }
+    }
 }
 
 /// Execute a single job: mark running → create worktree → run review → complete → cleanup.
@@ -506,6 +558,100 @@ mod tests {
             prompt_template: None,
             max_retries: 3,
         }
+    }
+
+    // -------------------------------------------------------------------
+    // resolve_base_repo_or_fail_job
+    //
+    // The runner no longer falls back to `std::env::current_dir()` when a
+    // policy is missing. Instead, it marks the job Failed and continues
+    // the loop. These tests cover the two branches.
+    // -------------------------------------------------------------------
+
+    fn policy_with_path(owner: &str, name: &str, path: &str) -> RepoPolicy {
+        RepoPolicy {
+            id: RepoId::new(owner, name),
+            skip_self_authored: true,
+            skip_reviewer_check: false,
+            review_on_push: true,
+            agent: AgentKind::Claude,
+            prompt_template: None,
+            model: None,
+            base_repo_path: Some(PathBuf::from(path)),
+            ignore_prs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_base_repo_or_fail_job_returns_path_when_policy_present() {
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        let leased = db.lease_next().expect("lease").expect("has job");
+
+        let policies = vec![policy_with_path("owner", "repo", "/tmp/fake")];
+        let result = resolve_base_repo_or_fail_job(&db, &policies, &leased);
+
+        assert_eq!(result, Some(PathBuf::from("/tmp/fake")));
+
+        // Job row must still be in its leased state — the helper is pure
+        // in the success path and must not mutate the store.
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        let row = jobs.iter().find(|j| j.id == job.id).expect("find");
+        assert_eq!(row.status, JobStatus::Leased);
+    }
+
+    #[test]
+    fn resolve_base_repo_or_fail_job_marks_failed_when_policy_missing() {
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        let leased = db.lease_next().expect("lease").expect("has job");
+
+        // Simulate a hot reload that removed the repo from the allowlist.
+        let policies: Vec<RepoPolicy> = Vec::new();
+        let result = resolve_base_repo_or_fail_job(&db, &policies, &leased);
+
+        assert!(
+            result.is_none(),
+            "helper must return None on missing policy"
+        );
+
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        let row = jobs.iter().find(|j| j.id == job.id).expect("find");
+        assert_eq!(
+            row.status,
+            JobStatus::Failed,
+            "job must be marked Failed when policy is missing"
+        );
+    }
+
+    #[test]
+    fn resolve_base_repo_or_fail_job_marks_failed_when_policy_has_no_path() {
+        // Defensive branch: `validate()` should prevent a policy with
+        // `base_repo_path = None` from reaching the runner, but the
+        // helper still needs to handle it gracefully because the compiler
+        // does not know about that invariant.
+        let db = Database::open_in_memory().expect("db");
+        let job = db.enqueue(sample_job()).expect("enqueue");
+        let leased = db.lease_next().expect("lease").expect("has job");
+
+        let policies = vec![RepoPolicy {
+            id: RepoId::new("owner", "repo"),
+            skip_self_authored: true,
+            skip_reviewer_check: false,
+            review_on_push: true,
+            agent: AgentKind::Claude,
+            prompt_template: None,
+            model: None,
+            base_repo_path: None,
+            ignore_prs: Vec::new(),
+        }];
+
+        let result = resolve_base_repo_or_fail_job(&db, &policies, &leased);
+
+        assert!(result.is_none());
+        let jobs = db.list_jobs(&JobFilter::default()).expect("list");
+        let row = jobs.iter().find(|j| j.id == job.id).expect("find");
+        assert_eq!(row.status, JobStatus::Failed);
     }
 
     #[test]

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,5 +1,6 @@
 //! Git worktree creation, cleanup, and TTL management.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::SystemTime;
@@ -148,9 +149,11 @@ pub fn remove(base_repo: &Path, worktree_path: &Path) -> Result<()> {
 ///    these are leftovers from jobs whose DB row was purged or never
 ///    written (crash recovery, manual `DELETE FROM jobs`, etc.).
 ///    Orphans older than `ttl_minutes` (by filesystem mtime) are
-///    removed: first by asking git via `orphan_base_repo`, and if
-///    that fails, by falling back to `std::fs::remove_dir_all` plus
-///    a best-effort `git worktree prune`.
+///    removed with `std::fs::remove_dir_all`. After the orphan sweep
+///    finishes, `git worktree prune` is run **once per distinct base
+///    repo** in `orphan_base_repos` so every allowlisted repo's admin
+///    dir gets its stale `.git/worktrees/<name>` entries cleaned up,
+///    not just whichever repo happened to be passed in.
 ///
 /// The `protected` set MUST include every worktree path the DB
 /// currently knows about across all statuses (queued / leased /
@@ -160,16 +163,25 @@ pub fn remove(base_repo: &Path, worktree_path: &Path) -> Result<()> {
 /// agent process to operate in a deleted directory. Callers can
 /// build this set from `JobStore::known_worktree_paths()`.
 ///
+/// `orphan_base_repos` is the complete set of base repo paths that
+/// could have owned an orphan. The caller (`worktree_cleanup_loop`)
+/// builds it by iterating `Config::repo_policies()` and collecting
+/// every resolved `base_repo_path`. Duplicates are allowed — the
+/// orphan pass deduplicates internally before running `git worktree
+/// prune`. An empty slice is legal but means no `prune` is attempted,
+/// so stale admin entries may linger until the next full sweep with a
+/// non-empty slice.
+///
 /// Returns every path that was successfully removed (tracked + orphan).
 pub fn cleanup_by_owner(
     owned: &[(PathBuf, PathBuf)],
     worktree_root: &Path,
     ttl_minutes: u64,
-    orphan_base_repo: &Path,
-    protected: &std::collections::HashSet<PathBuf>,
+    orphan_base_repos: &[PathBuf],
+    protected: &HashSet<PathBuf>,
 ) -> Result<Vec<PathBuf>> {
     let mut removed = Vec::new();
-    let mut tracked: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut tracked: HashSet<PathBuf> = HashSet::new();
 
     // --- Tracked pass -------------------------------------------------
     for (base_repo, wt_path) in owned {
@@ -202,6 +214,7 @@ pub fn cleanup_by_owner(
         }
     };
 
+    let mut swept_any_orphan = false;
     for entry in entries {
         let entry = entry
             .map_err(|e| ReviewqError::Process(format!("failed to read directory entry: {e}")))?;
@@ -238,30 +251,59 @@ pub fn cleanup_by_owner(
             "cleaning up orphan worktree"
         );
 
-        // Try git first (might work if the orphan happens to be
-        // registered under `orphan_base_repo`); otherwise fall back to
-        // plain filesystem removal plus `git worktree prune`.
-        match remove(orphan_base_repo, &path) {
-            Ok(()) => removed.push(path),
-            Err(git_err) => {
-                warn!(
-                    path = %path.display(),
-                    error = %git_err,
-                    "git worktree remove failed for orphan, falling back to fs::remove_dir_all"
-                );
-                if let Err(fs_err) = std::fs::remove_dir_all(&path) {
+        // Orphans have no reliable owner pointer, so skip the
+        // speculative `git worktree remove` (which would only succeed
+        // for the lucky case where the orphan's admin entry happened
+        // to live under a single known repo) and go straight to
+        // filesystem removal. The `git worktree prune` sweep below
+        // picks up the stale admin entries for every allowlisted base
+        // repo, which is what actually keeps `.git/worktrees/` clean
+        // in multi-repo installs.
+        if let Err(fs_err) = std::fs::remove_dir_all(&path) {
+            warn!(
+                path = %path.display(),
+                error = %fs_err,
+                "fs::remove_dir_all failed for orphan"
+            );
+            continue;
+        }
+        removed.push(path);
+        swept_any_orphan = true;
+    }
+
+    // Run `git worktree prune` once per distinct base repo so every
+    // allowlisted install gets its `.git/worktrees/` bookkeeping
+    // cleaned up, regardless of which repo owned the orphan. Skipped
+    // entirely when no orphans were reaped — `prune` is idempotent,
+    // but it is still a fork-per-repo and worth avoiding in the
+    // common steady-state cleanup cycle.
+    if swept_any_orphan {
+        let mut seen: HashSet<&Path> = HashSet::new();
+        for base in orphan_base_repos {
+            if !seen.insert(base.as_path()) {
+                continue;
+            }
+            // `Command::output()` returns `Ok` for any non-spawn
+            // failure — including `git` itself exiting non-zero
+            // (locked admin dir, read-only filesystem, etc.). Check
+            // the status explicitly so those cases do not silently
+            // leave stale bookkeeping behind.
+            match git().args(["worktree", "prune"]).current_dir(base).output() {
+                Ok(out) if !out.status.success() => {
                     warn!(
-                        path = %path.display(),
-                        error = %fs_err,
-                        "fs::remove_dir_all failed for orphan"
+                        base_repo = %base.display(),
+                        stderr = %String::from_utf8_lossy(&out.stderr),
+                        "`git worktree prune` exited non-zero for orphan bookkeeping; continuing"
                     );
-                    continue;
                 }
-                let _ = git()
-                    .args(["worktree", "prune"])
-                    .current_dir(orphan_base_repo)
-                    .output();
-                removed.push(path);
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(
+                        base_repo = %base.display(),
+                        error = %e,
+                        "failed to spawn `git worktree prune` for orphan bookkeeping; continuing"
+                    );
+                }
             }
         }
     }
@@ -327,8 +369,14 @@ mod tests {
         assert!(wt_path.exists());
 
         let owned = vec![(repo.clone(), wt_path.clone())];
-        let removed =
-            cleanup_by_owner(&owned, &wt_root, 60, &repo, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &owned,
+            &wt_root,
+            60,
+            std::slice::from_ref(&repo),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
 
         assert_eq!(removed, vec![wt_path.clone()]);
         assert!(!wt_path.exists(), "worktree should be gone");
@@ -357,8 +405,14 @@ mod tests {
             (repo_a.clone(), wt_a.clone()),
             (repo_b.clone(), wt_b.clone()),
         ];
-        let removed =
-            cleanup_by_owner(&owned, &wt_root, 60, &repo_a, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &owned,
+            &wt_root,
+            60,
+            std::slice::from_ref(&repo_a),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
 
         assert_eq!(removed.len(), 2);
         assert!(removed.contains(&wt_a));
@@ -385,8 +439,14 @@ mod tests {
             (repo.clone(), fake.clone()),
             (repo.clone(), wt_good.clone()),
         ];
-        let removed =
-            cleanup_by_owner(&owned, &wt_root, 60, &repo, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &owned,
+            &wt_root,
+            60,
+            std::slice::from_ref(&repo),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
 
         assert!(removed.contains(&wt_good));
         assert!(!wt_good.exists());
@@ -408,7 +468,14 @@ mod tests {
 
         // ttl=0 treats everything as expired, so the orphan pass kicks
         // in without having to manipulate mtime.
-        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &[],
+            &wt_root,
+            0,
+            std::slice::from_ref(&repo),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
 
         assert!(removed.contains(&orphan), "orphan not removed: {removed:?}");
         assert!(!orphan.exists(), "orphan dir should be gone");
@@ -426,7 +493,14 @@ mod tests {
         std::fs::create_dir_all(&recent).expect("create recent");
 
         // ttl = 60 minutes is plenty; the dir was just created.
-        let removed = cleanup_by_owner(&[], &wt_root, 60, &repo, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &[],
+            &wt_root,
+            60,
+            std::slice::from_ref(&repo),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
 
         assert!(
             !removed.contains(&recent),
@@ -446,7 +520,14 @@ mod tests {
         let unrelated = wt_root.join("not-ours");
         std::fs::create_dir_all(&unrelated).expect("create unrelated");
 
-        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &[],
+            &wt_root,
+            0,
+            std::slice::from_ref(&repo),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
 
         assert!(!removed.contains(&unrelated));
         assert!(unrelated.exists(), "non-reviewq dir must be untouched");
@@ -459,8 +540,123 @@ mod tests {
         init_repo(&repo);
         let wt_root = tmp.path().join("never-created");
 
-        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &HashSet::new()).expect("cleanup");
+        let removed = cleanup_by_owner(
+            &[],
+            &wt_root,
+            0,
+            std::slice::from_ref(&repo),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
         assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn cleanup_by_owner_orphan_pass_prunes_every_allowlisted_repo() {
+        // The pre-refactor version only ran `git worktree prune` on a
+        // single "orphan_base_repo" passed by the caller, so in a
+        // multi-repo install an orphan owned by a *different*
+        // allowlisted repo would get its directory removed but leave a
+        // stale `.git/worktrees/<name>` admin entry behind. The new
+        // signature takes the full slice of distinct base repos and
+        // prunes each of them; this test pins that behavior.
+        let tmp = TempDir::new().expect("tempdir");
+        let repo_a = tmp.path().join("repo_a");
+        let repo_b = tmp.path().join("repo_b");
+        init_repo(&repo_a);
+        init_repo(&repo_b);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        // Create a real worktree under repo_b and its `.git/worktrees`
+        // admin entry, then remove the actual working dir *without*
+        // telling git about it. That simulates an orphan whose only
+        // "owner" metadata lives inside repo_b's admin dir.
+        let sha_b = head_sha(&repo_b);
+        let wt_b = create(&repo_b, &wt_root, 42, &sha_b).expect("create wt_b");
+        assert!(wt_b.exists());
+
+        // Yank just the directory, leaving the `.git/worktrees/reviewq-42`
+        // entry behind. `git worktree prune` on repo_b must find and
+        // remove it. `git worktree prune` on repo_a must NOT touch it
+        // (wrong repo) — meaning the sweep only works if the caller
+        // passes repo_b in the slice, not just repo_a.
+        std::fs::remove_dir_all(&wt_b).expect("remove wt_b dir only");
+
+        // Re-create the directory so the orphan pass has something to
+        // reap. (It was the worktree we just removed, so recreating it
+        // keeps git's admin entry pointing at it but reviewq sees it
+        // as a stray dir.)
+        std::fs::create_dir_all(&wt_b).expect("recreate wt_b as orphan");
+        std::fs::write(wt_b.join("stale.txt"), "old").expect("write stale");
+
+        let orphan_admin = repo_b.join(".git/worktrees/reviewq-42");
+        assert!(
+            orphan_admin.exists(),
+            "precondition: git admin entry must still exist before sweep"
+        );
+
+        // Correct call: pass both base repos. Orphan gets reaped AND
+        // repo_b's admin entry gets pruned.
+        let removed = cleanup_by_owner(
+            &[],
+            &wt_root,
+            0,
+            &[repo_a.clone(), repo_b.clone()],
+            &HashSet::new(),
+        )
+        .expect("cleanup");
+
+        assert!(removed.contains(&wt_b), "orphan dir must be removed");
+        assert!(!wt_b.exists(), "orphan dir should be gone after sweep");
+        assert!(
+            !orphan_admin.exists(),
+            "repo_b's stale admin entry must be pruned: {:?}",
+            orphan_admin
+        );
+    }
+
+    #[test]
+    fn cleanup_by_owner_orphan_pass_leaves_bookkeeping_stale_when_wrong_repo_passed() {
+        // Companion to the test above: documents the old failure mode
+        // and guards against a regression where someone "optimizes" the
+        // caller to only pass a single repo. Orphan owned by repo_b,
+        // caller only passes repo_a — the *directory* is still removed
+        // (fs::remove_dir_all always works), but repo_b's admin entry
+        // remains stale because we never ran `git worktree prune`
+        // against repo_b.
+        let tmp = TempDir::new().expect("tempdir");
+        let repo_a = tmp.path().join("repo_a");
+        let repo_b = tmp.path().join("repo_b");
+        init_repo(&repo_a);
+        init_repo(&repo_b);
+        let wt_root = tmp.path().join("worktrees");
+        std::fs::create_dir_all(&wt_root).expect("create wt_root");
+
+        let sha_b = head_sha(&repo_b);
+        let wt_b = create(&repo_b, &wt_root, 99, &sha_b).expect("create wt_b");
+        std::fs::remove_dir_all(&wt_b).expect("remove wt_b dir only");
+        std::fs::create_dir_all(&wt_b).expect("recreate as orphan");
+
+        let orphan_admin = repo_b.join(".git/worktrees/reviewq-99");
+        assert!(orphan_admin.exists(), "precondition");
+
+        // Wrong call: only pass repo_a. Directory still reaped, but
+        // repo_b's bookkeeping stays stale.
+        let _ = cleanup_by_owner(
+            &[],
+            &wt_root,
+            0,
+            std::slice::from_ref(&repo_a),
+            &HashSet::new(),
+        )
+        .expect("cleanup");
+
+        assert!(!wt_b.exists(), "orphan dir is still reaped");
+        assert!(
+            orphan_admin.exists(),
+            "repo_b's admin entry stays stale when caller forgets to pass it"
+        );
     }
 
     #[test]
@@ -483,7 +679,8 @@ mod tests {
         let mut protected = HashSet::new();
         protected.insert(in_flight.clone());
 
-        let removed = cleanup_by_owner(&[], &wt_root, 0, &repo, &protected).expect("cleanup");
+        let removed = cleanup_by_owner(&[], &wt_root, 0, std::slice::from_ref(&repo), &protected)
+            .expect("cleanup");
 
         assert!(
             !removed.contains(&in_flight),


### PR DESCRIPTION
## Summary

Closes #10. reviewq silently fell back to `std::env::current_dir()` whenever `base_repo_path` was missing — both in the runner (`src/runner/mod.rs`) and in the cleanup loop (`src/main.rs::cleanup_once`) — which made the daemon's behavior depend on *where it was started*. This PR removes both fallbacks and makes the config structurally invalid if any allowlisted repo can't resolve a `base_repo_path`.

Validation is now two-tier:

- **`Config::validate()`** requires every allowlisted repo to resolve a `base_repo_path` (entry-level or via `repos.defaults`). Runs inside `from_yaml`, no filesystem I/O, blocks every subcommand uniformly — a missing field is a structural config error.
- **`Config::validate_paths()`** (new) is called only from the daemon and TUI startup paths and verifies each resolved `base_repo_path` both `exists()` and `is_dir()`. Read-only commands (`status` / `tail` / `open`) deliberately skip it so a broken filesystem path does not block post-mortem inspection. `reload_config` calls it too but degrades gracefully — a failing reload logs `warn!` and keeps the old config rather than crashing the daemon because the operator temporarily moved a clone aside.

The runner's `unwrap_or_else(|| current_dir())` is replaced with `resolve_base_repo_or_fail_job`, a small helper that handles the hot-reload race: when a repo is removed from the allowlist between enqueue and lease, the helper marks the in-flight job `Failed` and returns `None` instead of panicking or running the job against the wrong directory.

`worktree::cleanup_by_owner` now takes `orphan_base_repos: &[PathBuf]` instead of a single `&Path`. The orphan pass skips the old speculative `git worktree remove` (which only cleaned bookkeeping for the lucky case where the orphan happened to live under whatever repo the caller guessed at), runs `fs::remove_dir_all` directly, and then runs `git worktree prune` once per distinct base repo so multi-repo installs keep `.git/worktrees/` clean regardless of which repo owned the orphan. The prune call now checks exit status so a non-zero `git prune` (locked admin dir, read-only FS, etc.) no longer fails silently.

## Why

This closes the "it works on my machine" failure mode that motivated #10: reviewq would silently run against whatever directory you happened to `cd` into before starting the daemon. Fail-fast at config load is cheaper than debugging the wrong worktree in production.

The plan went through 4 rounds of review with codex (second-opinion) and the code was reviewed by `rust-reviewer`. Key findings from those rounds are baked into the diff:

- cleanup-side `current_dir()` fallback in `cleanup_once` was caught in round 1 and fixed (original plan only removed the runner-side fallback).
- Runner-side `expect("validated at load")` was rejected as a panic point because of the hot-reload race at `main.rs:346-364`; replaced with graceful `store.complete(..., Failed, None)`.
- Orphan pass `&Path` → `&[PathBuf]` was codex's alternative to a "pick the first allowlisted repo" heuristic that I proposed initially; the new design deterministically cleans bookkeeping for every allowlisted repo.
- HIGH finding from rust-reviewer: the `git worktree prune` output was checked only for spawn failure, not for non-zero exit — fixed in-place.

## Test plan

- [x] `make all` green locally (fmt + clippy `-D warnings` + 317 cargo tests + 71 hook self-tests)
- [x] 13 new tests added:
  - `validate_rejects_missing_base_repo_path` / `validate_rejects_missing_base_repo_path_for_one_of_many`
  - `validate_accepts_defaults_only_base_repo_path` / `validate_accepts_per_entry_base_repo_path`
  - `validate_paths_accepts_existing_directory` / `validate_paths_rejects_nonexistent_path` / `validate_paths_rejects_regular_file`
  - `resolve_base_repo_or_fail_job_returns_path_when_policy_present` / `..._marks_failed_when_policy_missing` / `..._marks_failed_when_policy_has_no_path`
  - `cleanup_by_owner_orphan_pass_prunes_every_allowlisted_repo` (positive: orphan owned by `repo_b`, caller passes both repos, `repo_b`'s admin entry is pruned)
  - `cleanup_by_owner_orphan_pass_leaves_bookkeeping_stale_when_wrong_repo_passed` (negative regression guard: passing only the wrong repo leaves the admin entry stale)
  - `reload_config_path_missing_keeps_old_config` (graceful degradation)
- [x] ~30 existing YAML fixtures updated with `base_repo_path: /tmp/fake` (mechanical — `validate()` does not touch the filesystem)
- [x] `base_repo_for_returns_none_when_nothing_set` rewritten to test a now-valid configuration (documenting the old failure state is structurally impossible)
- [ ] Manual smoke against the real daemon with (a) omitted field, (b) non-existent path, (c) regular file, (d) valid path — reviewer to confirm in their environment